### PR TITLE
Bug fixes

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -52,6 +52,7 @@ private:
 
 private slots:
     void onAccountsListed(const QList<TailAccountInfo>& foundAccounts);
+    void onCommandError(const QString& error, bool isSudoRequired);
     void settingsClosed();
     void loginFlowCompleted() const;
     void onNetworkReachabilityChanged(QNetworkInformation::Reachability newReachability);

--- a/src/TailFileReceiver.h
+++ b/src/TailFileReceiver.h
@@ -21,8 +21,6 @@ private:
     void startListening();
 
 private slots:
-    void processReadStdOut();
-    void processReadStdErr();
     void processFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
 private:

--- a/src/TailRunner.h
+++ b/src/TailRunner.h
@@ -17,6 +17,7 @@ class TailRunner : public QObject
 public:
     explicit TailRunner(const TailSettings& s, QObject* parent = nullptr);
 
+    void setOperator();
     void checkStatus();
     void getAccounts();
     void switchAccount(const QString& accountId);
@@ -39,6 +40,7 @@ private:
     std::unique_ptr<QProcess> pProcess;
     void* pUserData;
     enum class Command {
+        SetOperator,
         ListAccounts,
         SwitchAccount,
         Login,
@@ -62,6 +64,8 @@ signals:
     void loginFlowCompleted();
     void driveListed(const QList<TailDriveInfo>& drives, bool error, const QString& errorMsg);
     void fileSent(bool success, const QString& errorMsg, void* userData);
+
+    void commandError(const QString& errorMsg, bool requiresSudoError);
 
 private:
     void runCommand(const QString& cmd, QStringList args, bool jsonResult = false, bool usePkExec = false, void* userData = nullptr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@ int main(int argc, char *argv[])
 {
     QCoreApplication::setOrganizationName("grenangen");
     QCoreApplication::setOrganizationDomain("grenangen.se");
-    QCoreApplication::setApplicationName("tail-tray");
+    QCoreApplication::setApplicationName("Tail Tray");
 
     QApplication a(argc, argv);
     QApplication::setQuitOnLastWindowClosed(false);


### PR DESCRIPTION
This fixes two reported issues and fixes the file receiver issue we've been seeing. Seems that we where missing the --verbose flag for it to output the filename info we read to build the toast message when a file have been received.

Also fixes the name of the application in toast messages to be Tail Tray and not tail-tray as the cmd name.