### PR TITLE
Tray menu bug fixes

### DIFF
--- a/src/TrayMenuManager.cpp
+++ b/src/TrayMenuManager.cpp
@@ -132,9 +132,6 @@ void TrayMenuManager::buildConnectedMenu(TailStatus const* pTailStatus) const {
     pTrayMenu->clear();
     pTrayMenu->addAction(pConnected.get());
     pTrayMenu->addAction(pDisconnect.get());
-    pTrayMenu->addSeparator();
-    pThisDevice->setText(pTailStatus->user->loginName);
-    pTrayMenu->addAction(pThisDevice.get());
 
     pTrayMenu->addSeparator();
     pThisDevice->setText(pTailStatus->user->loginName);

--- a/src/TrayMenuManager.cpp
+++ b/src/TrayMenuManager.cpp
@@ -274,12 +274,15 @@ void TrayMenuManager::buildConnectedMenu(TailStatus const* pTailStatus) const {
     exitNodes->addAction(pExitNodeNone.get());
     for (int i = 0; i < pTailStatus->peers.count(); i++) {
         const auto& dev = pTailStatus->peers[i];
-        if (dev->online && dev->id != pTailStatus->self->id && dev->exitNodeOption) {
+        if (dev->id != pTailStatus->self->id && dev->exitNodeOption) {
             auto name = dev->getShortDnsName();
+            if (!dev->online)
+                name += " (offline)";
             auto* action = exitNodes->addAction(name);
             action->setCheckable(true);
             action->setChecked(dev->exitNode);
             action->setData(name);
+            action->setEnabled(dev->online);
 
             connect(action, &QAction::triggered, this, [this, action](bool) {
                 if (action->isChecked()) {


### PR DESCRIPTION
This should fix the double separator issue + show offline exit nodes correctly