### PR TITLE
Bugs/issue 37

### DIFF
--- a/src/TailRunner.cpp
+++ b/src/TailRunner.cpp
@@ -52,6 +52,12 @@ void TailRunner::setOperator() {
     runCommand(Command::SetOperator, "set", args, false, true);
 }
 
+void TailRunner::setExitNode(const QString& exitNode) {
+    QStringList args;
+    args << "--exit-node=" + (exitNode.isEmpty() ? "" : exitNode);
+    runCommand(Command::SetExitNode, "set", args, false, false);
+}
+
 void TailRunner::checkStatus() {
     runCommand(Command::Status, "status", QStringList(), true);
 }
@@ -107,23 +113,12 @@ void TailRunner::start(const bool usePkExec) {
 
     if (settings.advertiseAsExitNode()) {
         args << "--advertise-exit-node";
-    }
-    else {
+
         // Check if we have a exit node that we should use
-        const auto exitNode = settings.exitNodeInUse();
-        if (!exitNode.isEmpty()) {
-            qDebug() << "Will use exit node" << exitNode;
-            args << "--exit-node" << exitNode;
-
-            if (settings.exitNodeAllowLanAccess())
-                args << "--exit-node-allow-lan-access";
-            else
-                args << "--exit-node-allow-lan-access=false";
-        }
-        else {
-
-            args << "--exit-node=";
-        }
+        if (settings.exitNodeAllowLanAccess())
+            args << "--exit-node-allow-lan-access";
+        else
+            args << "--exit-node-allow-lan-access=false";
     }
 
     runCommand(Command::Connect, "up", args, false, usePkExec);
@@ -369,9 +364,7 @@ void TailRunner::onProcessFinished(const BufferedProcessWrapper* process, int ex
 #endif
             )
         {
-            QTimer::singleShot(1000, this, [this]() {
-                checkStatus();
-            });
+            checkStatus();
         }
     }
 }

--- a/src/TailRunner.h
+++ b/src/TailRunner.h
@@ -13,6 +13,7 @@
 
 enum class Command {
     SetOperator,
+    SetExitNode,
     ListAccounts,
     SwitchAccount,
     Login,
@@ -72,6 +73,7 @@ public:
     virtual ~TailRunner();
 
     void setOperator();
+    void setExitNode(const QString& exitNode = "");
     void checkStatus();
     void getAccounts();
     void switchAccount(const QString& accountId);

--- a/src/TailRunner.h
+++ b/src/TailRunner.h
@@ -14,6 +14,7 @@
 enum class Command {
     SetOperator,
     SetExitNode,
+    SetSettings,
     ListAccounts,
     SwitchAccount,
     Login,
@@ -74,6 +75,7 @@ public:
 
     void setOperator();
     void setExitNode(const QString& exitNode = "");
+    void applySettings(const TailSettings& s);
     void checkStatus();
     void getAccounts();
     void switchAccount(const QString& accountId);

--- a/src/TailSettings.cpp
+++ b/src/TailSettings.cpp
@@ -67,14 +67,6 @@ void TailSettings::startOnLogin(bool enabled) {
     settings.setValue("startOnLogin", enabled);
 }
 
-QString TailSettings::exitNodeInUse() const {
-    return settings.value("exitNodeInUse", "").toString();
-}
-
-void TailSettings::exitNodeInUse(const QString& nodeNameOrIp) {
-    settings.setValue("exitNodeInUse", nodeNameOrIp);
-}
-
 QString TailSettings::tailDriveMountPath() const {
     auto homePath = qEnvironmentVariable("HOME");
     return settings.value("tailDriveMountPath", homePath.append("/Tailscale")).toString();

--- a/src/TailSettings.h
+++ b/src/TailSettings.h
@@ -36,9 +36,6 @@ public:
     [[nodiscard]] bool startOnLogin() const;
     void startOnLogin(bool enabled);
 
-    [[nodiscard]] QString exitNodeInUse() const;
-    void exitNodeInUse(const QString& nodeNameOrIp);
-
     [[nodiscard]] QString tailDriveMountPath() const;
     void tailDriveMountPath(const QString& path);
 

--- a/src/TrayMenuManager.cpp
+++ b/src/TrayMenuManager.cpp
@@ -284,18 +284,16 @@ void TrayMenuManager::buildConnectedMenu(TailStatus const* pTailStatus) const {
             action->setEnabled(dev->online);
 
             connect(action, &QAction::triggered, this, [this, action](bool) {
+                auto devName = QString{};
+
                 if (action->isChecked()) {
-                    auto devName = action->data().toString();
-                    settings.exitNodeInUse(devName);
-                }
-                else {
-                    settings.exitNodeInUse("");
+                    devName = action->data().toString();
                 }
 
-                pExitNodeNone->setChecked(settings.exitNodeInUse().isEmpty());
+                pExitNodeNone->setChecked(devName.isEmpty());
 
                 settings.save();
-                pTailRunner->start();
+                pTailRunner->setExitNode(devName);
             });
         }
     }


### PR DESCRIPTION
Modify how we start tailscale and how we handle settings in general

 * Removed tracking of selected exit node (this can be read from tailscale status and thus this is what we do now)
 * Apply settings before tailscale up is called
 * Do not set settings when calling tailscale up

The above changes fixes issue #37 as well as it makes it a bit more robust in general, tailscale will start even if a setting is invalid etc now.