### PR TITLE
Feature - Use tailscale settings reader + fix login / logged out flows

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -164,6 +164,21 @@ void MainWindow::settingsReadyToRead() {
     qDebug() << "Run SSH: " << settings->runSSH;
     qDebug() << "No SNAT: " << settings->noSNAT;
     qDebug() << "Allow Exit node LAN Access: " << settings->exitNodeAllowLANAccess;
+
+    auto isUserOperator = settings->operatorUser == qEnvironmentVariable("USER");
+    if (!isUserOperator) {
+        const auto response = QMessageBox::warning(nullptr,
+           "Failed to run command",
+           "To be able to control tailscale you need to be root or set yourself as operator. Do you want to set yourself as operator?",
+           QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok);
+
+        if (response == QMessageBox::Ok) {
+            pCurrentExecution->setOperator();
+        }
+    }
+    else {
+        pCurrentExecution->getAccounts();
+    }
 }
 
 void MainWindow::onAccountsListed(const QList<TailAccountInfo>& foundAccounts) {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -51,6 +51,7 @@ private:
     QMap<QString, QDateTime> seenWarnings;
 
 private slots:
+    void settingsReadyToRead();
     void onAccountsListed(const QList<TailAccountInfo>& foundAccounts);
     void onCommandError(const QString& error, bool isSudoRequired);
     void settingsClosed();

--- a/src/TailRunner.cpp
+++ b/src/TailRunner.cpp
@@ -38,12 +38,29 @@ namespace
 TailRunner::TailRunner(const TailSettings& s, QObject* parent)
     : QObject(parent)
     , settings(s)
-    , processes()
-{ }
+    , processes() {
+}
 
 TailRunner::~TailRunner()
 {
     runCompletedCleanup();
+}
+
+void TailRunner::bootstrap() {
+    // NOTE: The bootstrap to get this started is as follows:
+    // 1. Read settings from Tailscale daemon
+    // 2. Once that is successfully read, it will internally call getAccounts()
+    // 3. Once getAccounts() have returned it will once again internally call getStatus()
+    // 4. Once getStatus() returns we are in a running state, eg logged in and connected OR logged out OR logged in and disconnected etc...
+
+    readSettings();
+}
+
+void TailRunner::readSettings() {
+    QStringList args;
+    args << "prefs";
+
+    runCommand(Command::GetSettings, "debug", args, false, false);
 }
 
 void TailRunner::setOperator() {
@@ -212,6 +229,20 @@ void TailRunner::onProcessCanReadStdOut(const BufferedProcessWrapper* wrapper) {
             parseStatusResponse(obj);
             break;
         }
+        case Command::GetSettings: {
+            QJsonParseError parseError;
+            const QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
+
+            if (parseError.error != QJsonParseError::NoError)
+            {
+                qDebug() << parseError.errorString();
+                return;
+            }
+
+            const QJsonObject obj = doc.object();
+            parseSettingsResponse(obj);
+            break;
+        }
         case Command::ListAccounts: {
             const QString raw(data);
             const QList<TailAccountInfo> accounts = TailAccountInfo::parseAllFound(raw);
@@ -322,13 +353,9 @@ void TailRunner::onProcessFinished(const BufferedProcessWrapper* process, int ex
             // and change the operator to current user since we won't be able to control it otherwise
             // as a regular user
 
-            const auto response = QMessageBox::warning(nullptr,
-               "Failed to run command",
-               "To be able to control tailscale you need to be root or set yourself as operator. Do you want to set yourself as operator?",
-               QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok);
-
             const QString info(process->process()->readAllStandardOutput());
             if (info.contains("https://login.tailscale.com")) {
+                qDebug() << "Login required!";
                 static QRegularExpression regex(R"(https:\/\/login\.tailscale\.com\/a\/[a-zA-Z0-9]+)");
                 const QRegularExpressionMatch match = regex.match(info);
                 if (match.hasMatch()) {
@@ -340,10 +367,25 @@ void TailRunner::onProcessFinished(const BufferedProcessWrapper* process, int ex
                         QDesktopServices::openUrl(QUrl(url));
                 }
             }
+            else {
+                bool isUserOperator = false;
+                if (currentPrefs != nullptr) {
+                    isUserOperator = currentPrefs->operatorUser == qEnvironmentVariable("USER");
+                }
 
-            if (response == QMessageBox::Ok) {
-                process->process()->close();
-                start(true);
+                qDebug() << "Failed to execute. Is current user operator? " << (isUserOperator ? "Yes" : "No");
+
+                if (!isUserOperator) {
+                    const auto response = QMessageBox::warning(nullptr,
+                       "Failed to run command",
+                       "To be able to control tailscale you need to be root or set yourself as operator. Do you want to set yourself as operator?",
+                       QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok);
+
+                    if (response == QMessageBox::Ok) {
+                        process->process()->close();
+                        start(true);
+                    }
+                }
             }
         }
         else if (commandInfo == Command::SendFile) {
@@ -352,6 +394,10 @@ void TailRunner::onProcessFinished(const BufferedProcessWrapper* process, int ex
     }
     else {
         if (commandInfo == Command::SwitchAccount || commandInfo == Command::Login) {
+            getAccounts();
+        }
+        else if (commandInfo == Command::GetSettings) {
+            emit settingsRead();
             getAccounts();
         }
         else if (commandInfo == Command::ListAccounts) {
@@ -375,6 +421,10 @@ void TailRunner::onProcessFinished(const BufferedProcessWrapper* process, int ex
 
 void TailRunner::parseStatusResponse(const QJsonObject& obj) {
     emit statusUpdated(TailStatus::parse(obj));
+}
+
+void TailRunner::parseSettingsResponse(const QJsonObject& obj) {
+    currentPrefs = std::move(CurrentTailPrefs::parse(obj));
 }
 
 bool TailRunner::hasPendingCommandOfType(const Command cmdType) const {

--- a/src/TailRunner.cpp
+++ b/src/TailRunner.cpp
@@ -95,11 +95,15 @@ void TailRunner::applySettings(const TailSettings& s) {
     if (settings.advertiseAsExitNode()) {
         args << "--advertise-exit-node";
 
-        // Check if we have a exit node that we should use
+        // Check if we have an exit node that we should use
         if (settings.exitNodeAllowLanAccess())
             args << "--exit-node-allow-lan-access";
         else
             args << "--exit-node-allow-lan-access=false";
+    }
+    else {
+        args << "--advertise-exit-node=false";
+        args << "--exit-node-allow-lan-access=false";
     }
 
     qDebug() << "TailRunner::applySettings: " << args;
@@ -386,6 +390,10 @@ void TailRunner::onProcessFinished(const BufferedProcessWrapper* process, int ex
         }
         else if (commandInfo == Command::GetSettings) {
             emit settingsRead();
+        }
+        else if (commandInfo == Command::SetExitNode) {
+            readSettings();
+            checkStatus();
         }
         else if (commandInfo == Command::ListAccounts) {
             checkStatus();

--- a/src/TailRunner.cpp
+++ b/src/TailRunner.cpp
@@ -374,18 +374,6 @@ void TailRunner::onProcessFinished(const BufferedProcessWrapper* process, int ex
                 }
 
                 qDebug() << "Failed to execute. Is current user operator? " << (isUserOperator ? "Yes" : "No");
-
-                if (!isUserOperator) {
-                    const auto response = QMessageBox::warning(nullptr,
-                       "Failed to run command",
-                       "To be able to control tailscale you need to be root or set yourself as operator. Do you want to set yourself as operator?",
-                       QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok);
-
-                    if (response == QMessageBox::Ok) {
-                        process->process()->close();
-                        start(true);
-                    }
-                }
             }
         }
         else if (commandInfo == Command::SendFile) {
@@ -398,7 +386,6 @@ void TailRunner::onProcessFinished(const BufferedProcessWrapper* process, int ex
         }
         else if (commandInfo == Command::GetSettings) {
             emit settingsRead();
-            getAccounts();
         }
         else if (commandInfo == Command::ListAccounts) {
             checkStatus();

--- a/src/TailRunner.h
+++ b/src/TailRunner.h
@@ -14,6 +14,7 @@
 enum class Command {
     SetOperator,
     SetExitNode,
+    GetSettings,
     SetSettings,
     ListAccounts,
     SwitchAccount,
@@ -73,6 +74,9 @@ public:
     explicit TailRunner(const TailSettings& s, QObject* parent = nullptr);
     virtual ~TailRunner();
 
+    void bootstrap();
+
+    void readSettings();
     void setOperator();
     void setExitNode(const QString& exitNode = "");
     void applySettings(const TailSettings& s);
@@ -95,11 +99,15 @@ public:
 
     void sendFile(const QString& targetDevice, const QString& localFilePath, void* userData = nullptr);
 
+    [[nodiscard]] const CurrentTailPrefs* currentSettings() const { return currentPrefs.get(); }
+
 private:
     const TailSettings& settings;
+    std::unique_ptr<CurrentTailPrefs> currentPrefs;
     std::vector<BufferedProcessWrapper*> processes;
 
 signals:
+    void settingsRead();
     void accountsListed(const QList<TailAccountInfo>& accounts);
     void statusUpdated(TailStatus* newStatus);
     void loginFlowCompleted();
@@ -111,6 +119,7 @@ signals:
 private:
     void runCommand(Command cmdType, const QString& cmd, const QStringList& args, bool jsonResult = false, bool usePkExec = false, void* userData = nullptr);
     void parseStatusResponse(const QJsonObject& obj);
+    void parseSettingsResponse(const QJsonObject& obj);
 
     [[nodiscard]] bool hasPendingCommandOfType(Command cmdType) const;
     void runCompletedCleanup();

--- a/src/TailRunner.h
+++ b/src/TailRunner.h
@@ -38,7 +38,7 @@ class BufferedProcessWrapper : public QObject
 {
     Q_OBJECT
 public:
-    explicit BufferedProcessWrapper(Command cmd, QObject* parent = nullptr);
+    explicit BufferedProcessWrapper(Command cmd, bool emitOnActualSignals = false, QObject* parent = nullptr);
 
     /// Start the process with the given command and arguments
     void start(const QString& cmd, QStringList args, bool jsonResult, bool usePkExec, void* userData);
@@ -59,6 +59,7 @@ private slots:
     void onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
 private:
+    bool bEmitOnActualSignals;
     std::unique_ptr<QProcess> proc;
     void* pUserData;
     Command eCommand;

--- a/src/TrayMenuManager.cpp
+++ b/src/TrayMenuManager.cpp
@@ -391,7 +391,8 @@ void TrayMenuManager::setupWellKnownActions() const {
                 if (wnd->isVisible())
                     wnd->hide();
                 else {
-                    wnd->syncSettingsToUi();
+                    // NOTE: When settings are read, they will call settings to UI so will be in sync on show
+                    pTailRunner->readSettings();
                     wnd->showSettingsTab();
                 }
             }

--- a/src/TrayMenuManager.cpp
+++ b/src/TrayMenuManager.cpp
@@ -281,7 +281,9 @@ void TrayMenuManager::buildConnectedMenu(TailStatus const* pTailStatus) const {
             action->setCheckable(true);
             action->setChecked(dev->exitNode);
             action->setData(name);
-            action->setEnabled(dev->online);
+
+            // You can't use a exit node if you are advertising as exit node
+            action->setEnabled(dev->online && !settings.advertiseAsExitNode());
 
             connect(action, &QAction::triggered, this, [this, action](bool) {
                 auto devName = QString{};

--- a/src/models/TailStatus.h
+++ b/src/models/TailStatus.h
@@ -42,7 +42,7 @@ public:
     bool drivesConfigured = true;
 
     static TailStatus* parse(const QJsonObject& obj) {
-        const auto newStatus = new TailStatus{};
+        auto* newStatus = new TailStatus{};
         newStatus->version = safeReadStr(obj, "Version");
         newStatus->tun = safeReadBool(obj, "TUN");
         newStatus->backendState = safeReadStr(obj, "BackendState");
@@ -101,6 +101,127 @@ public:
         }
 
         return newStatus;
+    }
+};
+
+class TailPrefsConfig final : QObject {
+    Q_OBJECT
+public:
+    QString privateNodeKey;
+    QString oldPrivateNodeKey;
+    std::unique_ptr<TailUser> user;
+    QString networkLockKey;
+    QString nodeID;
+
+    static std::unique_ptr<TailPrefsConfig> parse(const QJsonObject& obj) {
+        auto config = std::make_unique<TailPrefsConfig>();
+        config->privateNodeKey = safeReadStr(obj, "PrivateNodeKey");
+        config->oldPrivateNodeKey = safeReadStr(obj, "OldPrivateNodeKey");
+        config->networkLockKey = safeReadStr(obj, "NetworkLockKey");
+        config->nodeID = safeReadStr(obj, "NodeID");
+        config->user = TailUser::parse(obj["UserProfile"].toObject());
+        return config;
+    }
+};
+
+class CurrentTailPrefs final : public QObject {
+    Q_OBJECT
+public:
+    QString controlURL;
+    bool routeAll;
+    QString exitNodeId;
+    QString exitNodeIp;
+    QString internalExitNodePrior;
+    bool exitNodeAllowLANAccess;
+    bool corpDNS;
+    bool runSSH;
+    bool runWebClient;
+    bool wantRunning;
+    bool loggedOut;
+    bool shieldsUp;
+    QList<QString> advertiseTags;
+    QString hostname;
+    bool notepadURLs;
+    QList<QString> advertiseRoutes;
+    QList<QString> advertiseServices;
+    bool noSNAT;
+    bool noStatefulFiltering;
+    int netfilterMode;
+    QString operatorUser;
+    bool autoUpdate_Check;
+    bool autoUpdate_Apply;
+    bool appConnector_Advertise;
+    bool postureChecking;
+    QString netfilterKind;
+    QList<QString> driveShares;
+    bool allowSingleHosts;
+    std::unique_ptr<TailPrefsConfig> config;
+
+    static std::unique_ptr<CurrentTailPrefs> parse(const QJsonObject& obj) {
+        auto prefs = std::make_unique<CurrentTailPrefs>();
+
+        prefs->controlURL = safeReadStr(obj, "ControlURL");
+        prefs->routeAll = safeReadBool(obj, "RouteAll");
+        prefs->exitNodeId = safeReadStr(obj, "ExitNodeID");
+        prefs->exitNodeIp = safeReadStr(obj, "ExitNodeIP");
+        prefs->internalExitNodePrior = safeReadStr(obj, "InternalExitNodePrior");
+        prefs->exitNodeAllowLANAccess = safeReadBool(obj, "ExitNodeAllowLANAccess");
+        prefs->corpDNS = safeReadBool(obj, "CorpDNS");
+        prefs->runSSH = safeReadBool(obj, "RunSSH");
+        prefs->runWebClient = safeReadBool(obj, "RunWebClient");
+        prefs->wantRunning = safeReadBool(obj, "WantRunning");
+        prefs->loggedOut = safeReadBool(obj, "LoggedOut");
+        prefs->shieldsUp = safeReadBool(obj, "ShieldsUp");
+
+        // AdvertiseTags
+        if (obj.contains("AdvertiseTags") && !obj["AdvertiseTags"].isNull()) {
+            for (const auto& tag : obj["AdvertiseTags"].toArray()) {
+                prefs->advertiseTags.emplace_back(tag.toString());
+            }
+        }
+
+        prefs->hostname = safeReadStr(obj, "Hostname");
+        prefs->notepadURLs = safeReadBool(obj, "NotepadURLs");
+
+        // AdvertiseRoutes
+        if (obj.contains("AdvertiseRoutes") && !obj["AdvertiseRoutes"].isNull()) {
+            for (const auto& route : obj["AdvertiseRoutes"].toArray()) {
+                prefs->advertiseRoutes.emplace_back(route.toString());
+            }
+        }
+
+        // AdvertiseServices
+        if (obj.contains("AdvertiseServices") && !obj["AdvertiseServices"].isNull()) {
+            for (const auto& route : obj["AdvertiseRoutes"].toArray()) {
+                prefs->advertiseRoutes.emplace_back(route.toString());
+            }
+        }
+
+        prefs->noSNAT = safeReadBool(obj, "NoSNAT");
+        prefs->noStatefulFiltering = safeReadBool(obj, "NoStatefulFiltering");
+        prefs->netfilterMode = safeReadInt(obj, "NetfilterMode");
+        prefs->operatorUser = safeReadStr(obj, "OperatorUser");
+
+        // AutoUpdate
+        // TBD
+
+        // AppConnector
+        // TBD
+
+        prefs->postureChecking = safeReadBool(obj, "PostureChecking");
+        prefs->netfilterKind = safeReadStr(obj, "NetfilterKind");
+        prefs->allowSingleHosts = safeReadBool(obj, "AllowSingleHosts");
+
+        // DriveShares
+        if (obj.contains("DriveShares") && !obj["DriveShares"].isNull()) {
+            for (const auto& drive : obj["DriveShares"].toArray()) {
+                prefs->driveShares.emplace_back(drive.toString());
+            }
+        }
+
+        // Config
+        prefs->config = TailPrefsConfig::parse(obj["Config"].toObject());
+        return prefs;
     }
 };
 

--- a/src/models/TailStatus.h
+++ b/src/models/TailStatus.h
@@ -127,35 +127,192 @@ public:
 class CurrentTailPrefs final : public QObject {
     Q_OBJECT
 public:
+    // ControlURL is the URL of the control server to use.
     QString controlURL;
+
+    // RouteAll specifies whether to accept subnets advertised by
+	// other nodes on the Tailscale network. Note that this does not
+	// include default routes (0.0.0.0/0 and ::/0), those are
+	// controlled by ExitNodeID/IP below.
     bool routeAll;
+
+    // ExitNodeID and ExitNodeIP specify the node that should be used
+	// as an exit node for internet traffic. At most one of these
+	// should be non-zero.
+	//
+	// The preferred way to express the chosen node is ExitNodeID, but
+	// in some cases it's not possible to use that ID (e.g. in the
+	// linux CLI, before tailscaled has a netmap). For those
+	// situations, we allow specifying the exit node by IP, and
+	// ipnlocal.LocalBackend will translate the IP into an ID when the
+	// node is found in the netmap.
+	//
+	// If the selected exit node doesn't exist (e.g. it's not part of
+	// the current tailnet), or it doesn't offer exit node services, a
+	// blackhole route will be installed on the local system to
+	// prevent any traffic escaping to the local network.
     QString exitNodeId;
     QString exitNodeIp;
+
+    // InternalExitNodePrior is the most recently used ExitNodeID in string form. It is set by
+	// the backend on transition from exit node on to off and used by the
+	// backend.
+	//
+	// As an Internal field, it can't be set by LocalAPI clients, rather it is set indirectly
+	// when the ExitNodeID value is zero'd and via the set-use-exit-node-enabled endpoint.
     QString internalExitNodePrior;
+
+    // ExitNodeAllowLANAccess indicates whether locally accessible subnets should be
+    // routed directly or via the exit node.
     bool exitNodeAllowLANAccess;
+
+    // CorpDNS specifies whether to install the Tailscale network's
+    // DNS configuration, if it exists.
+    // NOTE: Maps to Use Tailscale DNS settings
     bool corpDNS;
+
+    // RunSSH bool is whether this node should run an SSH
+    // server, permitting access to peers according to the
+    // policies as configured by the Tailnet's admin(s).
     bool runSSH;
+
+    // RunWebClient bool is whether this node should expose
+    // its web client over Tailscale at port 5252,
+    // permitting access to peers according to the
+    // policies as configured by the Tailnet's admin(s).
     bool runWebClient;
+
+    // WantRunning indicates whether networking should be active on
+    // this node.
     bool wantRunning;
+
+    // LoggedOut indicates whether the user intends to be logged out.
+    // There are other reasons we may be logged out, including no valid
+    // keys.
+    // We need to remember this state so that, on next startup, we can
+    // generate the "Login" vs "Connect" buttons correctly, without having
+    // to contact the server to confirm our nodekey status first.
     bool loggedOut;
+
+    // ShieldsUp indicates whether to block all incoming connections,
+    // regardless of the control-provided packet filter. If false, we
+    // use the packet filter as provided. If true, we block incoming
+    // connections. This overrides tailcfg.Hostinfo's ShieldsUp.
     bool shieldsUp;
+
+    // AdvertiseTags specifies groups that this node wants to join, for
+    // purposes of ACL enforcement. These can be referenced from the ACL
+    // security policy. Note that advertising a tag doesn't guarantee that
+    // the control server will allow you to take on the rights for that
+    // tag.
     QList<QString> advertiseTags;
+
+    // Hostname is the hostname to use for identifying the node. If
+    // not set, os.Hostname is used.
     QString hostname;
+
+    // NotepadURLs is a debugging setting that opens OAuth URLs in
+    // notepad.exe on Windows, rather than loading them in a browser.
+    //
+    // apenwarr 2020-04-29: Unfortunately this is still needed sometimes.
+    // Windows' default browser setting is sometimes screwy and this helps
+    // users narrow it down a bit.
     bool notepadURLs;
+
+#if defined(WINDOWS_BUILD)
+    // ForceDaemon specifies whether a platform that normally
+    // operates in "client mode" (that is, requires an active user
+    // logged in with the GUI app running) should keep running after the
+    // GUI ends and/or the user logs out.
+    //
+    // The only current applicable platform is Windows. This
+    // forced Windows to go into "server mode" where Tailscale is
+    // running even with no users logged in. This might also be
+    // used for macOS in the future. This setting has no effect
+    // for Linux/etc, which always operate in daemon mode.
+    bool forceDaemon;
+#endif
+
+    // AdvertiseRoutes specifies CIDR prefixes to advertise into the
+    // Tailscale network as reachable through the current
+    // node.
     QList<QString> advertiseRoutes;
+
+    // AdvertiseServices specifies the list of services that this
+    // node can serve as a destination for. Note that an advertised
+    // service must still go through the approval process from the
+    // control server.
     QList<QString> advertiseServices;
+
+    // NoSNAT specifies whether to source NAT traffic going to
+    // destinations in AdvertiseRoutes. The default is to apply source
+    // NAT, which makes the traffic appear to come from the router
+    // machine rather than the peer's Tailscale IP.
+    //
+    // Disabling SNAT requires additional manual configuration in your
+    // network to route Tailscale traffic back to the subnet relay
+    // machine.
+    //
+    // Linux-only.
     bool noSNAT;
+
+    // NoStatefulFiltering specifies whether to apply stateful filtering when
+    // advertising routes in AdvertiseRoutes. The default is to not apply
+    // stateful filtering.
+    //
+    // To allow inbound connections from advertised routes, both NoSNAT and
+    // NoStatefulFiltering must be true.
+    //
+    // This is an opt.Bool because it was first added after NoSNAT, with a
+    // backfill based on the value of that parameter. The backfill has been
+    // removed since then, but the field remains an opt.Bool.
+    //
+    // Linux-only.
     bool noStatefulFiltering;
+
+    // NetfilterMode specifies how much to manage netfilter rules for
+    // Tailscale, if at all.
     int netfilterMode;
+
+    // OperatorUser is the local machine user name who is allowed to
+    // operate tailscaled without being root or using sudo.
     QString operatorUser;
+
+    // TODO: Check/Parse in JSON
+    // ProfileName is the desired name of the profile. If empty, then the user's
+    // LoginName is used. It is only used for display purposes in the client UI
+    // and CLI.
+    QString profileName;
+
+    // AutoUpdate sets the auto-update preferences for the node agent. See
+    // AutoUpdatePrefs docs for more details.
     bool autoUpdate_Check;
     bool autoUpdate_Apply;
+
+    // AppConnector sets the app connector preferences for the node agent. See
+    // AppConnectorPrefs docs for more details.
     bool appConnector_Advertise;
+
+    // PostureChecking enables the collection of information used for device
+    // posture checks.
     bool postureChecking;
+
+    // NetfilterKind specifies what netfilter implementation to use.
+    //
+    // Linux-only.
     QString netfilterKind;
+
+    // DriveShares are the configured DriveShares, stored in increasing order
+    // by name.
+    // TODO: Parse from JSON. Data structure, see https://github.com/tailscale/tailscale/blob/main/drive/remote.go#L34
     QList<QString> driveShares;
+
+    // No longer used...
     bool allowSingleHosts;
+
     std::unique_ptr<TailPrefsConfig> config;
+
+    [[nodiscard]] bool isExitNode() const { return advertiseRoutes.count() > 0; }
 
     static std::unique_ptr<CurrentTailPrefs> parse(const QJsonObject& obj) {
         auto prefs = std::make_unique<CurrentTailPrefs>();

--- a/src/models/TailUser.h
+++ b/src/models/TailUser.h
@@ -22,18 +22,20 @@ public:
     QList<QString> roles;
 
     static std::unique_ptr<TailUser> parse(const QJsonObject& obj, long long userId) {
-        auto user = std::make_unique<TailUser>();
-
         auto idKey = QString::number(userId);
         if (!obj.contains(idKey) || obj[idKey].isNull()) {
-            return user;
+            return std::make_unique<TailUser>();
         }
 
         // Get the user object based on the user id (user id comes from the self part in the same doc)
         auto thisUser = obj[idKey].toObject();
+        return parse(thisUser);
+    }
 
-        user->id = userId;
+    static std::unique_ptr<TailUser> parse(const QJsonObject& thisUser) {
+        auto user = std::make_unique<TailUser>();
 
+        user->id = safeReadLong(thisUser, "ID");
         user->loginName = safeReadStr(thisUser, "LoginName");
         user->displayName = safeReadStr(thisUser, "DisplayName");
         user->profilePicUrl = safeReadStr(thisUser, "ProfilePicUrl");


### PR DESCRIPTION
This CL mainly adds a settings sync from tailscale and combines it with our custom settings for Tail Tray
It also fixes a soft lock/hang in the client if you tried to login from it after the introduction of the buffered proc reader