### PR TITLE
Add advertiseRoutes in TailRunner

### DIFF
--- a/src/TailRunner.cpp
+++ b/src/TailRunner.cpp
@@ -25,6 +25,7 @@ namespace
             case Command::SetExitNode: return "SetExitNode";
             case Command::GetSettings: return "GetSettings";
             case Command::SetSettings: return "SetSettings";
+            case Command::AdvertiseRoutes: return "AdvertiseRoutes";
 #if defined(DAVFS_ENABLED)
             case Command::Drive: return "Drive";
             case Command::DriveAdd: return "DriveAdd";
@@ -76,6 +77,14 @@ void TailRunner::setExitNode(const QString& exitNode) {
     QStringList args;
     args << "--exit-node=" + (exitNode.isEmpty() ? "" : exitNode);
     runCommand(Command::SetExitNode, "set", args, false, false);
+}
+
+void TailRunner::advertiseRoutes(const QList<QString>& definedRoutes) {
+    QStringList args;
+    args << "--advertise-routes";
+    args << definedRoutes.join(",");
+
+    runCommand(Command::AdvertiseRoutes, "set", args, false, false);
 }
 
 void TailRunner::applySettings(const TailSettings& s) {

--- a/src/TailRunner.h
+++ b/src/TailRunner.h
@@ -25,6 +25,7 @@ enum class Command {
     SettingsChange,
     Status,
     SendFile,
+    AdvertiseRoutes,
 #if defined(DAVFS_ENABLED)
     Drive,
     DriveAdd,
@@ -80,6 +81,7 @@ public:
     void readSettings();
     void setOperator();
     void setExitNode(const QString& exitNode = "");
+    void advertiseRoutes(const QList<QString>& definedRoutes);
     void applySettings(const TailSettings& s);
     void checkStatus();
     void getAccounts();


### PR DESCRIPTION
This will add UI and logic to be able to set/modify advertise routes settings.
A route can be defined like:
* `10.0.0.0/8`
* `192.168.1.0/24`
* etc... 
