### PR TITLE
Moving stuff for TailDrive into it's own drive manager + fix bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ set(PROJECT_SOURCES
         src/TailFileReceiver.h
         src/TailRunner.h
         src/TailRunner.cpp
+        src/TailDriveUiManager.h
+        src/TailDriveUiManager.cpp
         src/ManageDriveWindow.h
         src/ManageDriveWindow.cpp
         src/ManageDriveWindow.ui

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -24,6 +24,10 @@ MainWindow::MainWindow(QWidget* parent)
     , eCurrentState(TailState::NoAccount)
     , pNetworkStateMonitor(std::make_unique<NetworkStateMonitor>(this))
     , pDnsStatus(std::make_unique<TailDnsStatus>())
+#if defined(DAVFS_ENABLED)
+    , pTailDriveUiManager()
+#endif
+    , settings(this)
 {
     ui->setupUi(this);
 
@@ -34,42 +38,11 @@ MainWindow::MainWindow(QWidget* parent)
 
 // Davfs or not
 #if defined(DAVFS_ENABLED)
+    pTailDriveUiManager = std::make_unique<TailDriveUiManager>(ui.get(), pCurrentExecution.get(), this);
+    
     // Make sure to adjust tail drive based on the check state
     if (settings.tailDriveEnabled()) {
         ui->tabWidget->insertTab(3, ui->tabTailDrive, QIcon::fromTheme("drive-removable-media"), "Tail Drive");
-    }
-
-    connect(ui->btnAddTailDrive, &QPushButton::clicked,
-            this, &MainWindow::addTailDriveButtonClicked);
-
-    connect(ui->btnRemoveSelectedTailDrive, &QPushButton::clicked,
-            this, &MainWindow::removeTailDriveButtonClicked);
-
-    connect(ui->chkUseTailDrive, &QCheckBox::clicked,
-            this, [this]() {
-                auto checked = ui->chkUseTailDrive->isChecked();
-                settings.tailDriveEnabled(checked);
-
-                if (checked) {
-                    ui->tabWidget->insertTab(3, ui->tabTailDrive, QIcon::fromTheme("drive-removable-media"), "Tail Drive");
-                }
-                else {
-                    ui->tabWidget->removeTab(3);
-                }
-            });
-
-    connect(ui->btnSelectTailDriveMountPath, &QPushButton::clicked,
-            this, &MainWindow::selectTailDriveMountPath);
-
-    if (!isTailDriveFileAlreadySetup()) {
-        ui->btnTailDriveFixDavFsMountSetup->setEnabled(true);
-        ui->btnTailDriveFixDavFsMountSetup->setText(tr("Fix it for me"));
-        connect(ui->btnTailDriveFixDavFsMountSetup, &QPushButton::clicked,
-                this, &MainWindow::fixTailDriveDavFsSetup);
-    }
-    else {
-        ui->btnTailDriveFixDavFsMountSetup->setEnabled(false);
-        ui->btnTailDriveFixDavFsMountSetup->setText(tr("Configured and ready"));
     }
 
     connect(pCurrentExecution.get(), &TailRunner::driveListed, this, &MainWindow::drivesListed);
@@ -308,7 +281,7 @@ void MainWindow::drivesListed(const QList<TailDriveInfo>& drives, bool error, co
     if (error) {
         pTailStatus->drivesConfigured = false;
         qDebug() << errorMsg;
-        qDebug() << "To read more about configuring taill drives, see https://tailscale.com/kb/1369/taildrive";
+        qDebug() << "To read more about configuring tail drives, see https://tailscale.com/kb/1369/taildrive";
 
         QMessageBox::information(nullptr,
             tr("Tail Drive - Error"),
@@ -326,87 +299,8 @@ void MainWindow::drivesListed(const QList<TailDriveInfo>& drives, bool error, co
     // Refresh the tray icon menus
     pTrayManager->stateChangedTo(eCurrentState, pTailStatus.get());
 
-    tailDrivesToUi();
-}
-
-void MainWindow::addTailDriveButtonClicked() const {
-    ManageDriveWindow dlg(TailDriveInfo{}, nullptr);
-    auto result = dlg.exec();
-    if (result == QDialog::Accepted) {
-        auto newDrive = dlg.driveInfo();
-        pCurrentExecution->addDrive(newDrive);
-
-        pTailStatus->drives.emplace_back(newDrive);
-        tailDrivesToUi();
-    }
-}
-
-void MainWindow::removeTailDriveButtonClicked() const {
-    auto selectedItems = ui->twSharedDrives->selectedItems();
-    if (selectedItems.count() < 1) {
-        return;
-    }
-
-    auto row = ui->twSharedDrives->row(selectedItems.first());
-    const auto& drive = pTailStatus->drives[row];
-
-    auto answer = QMessageBox::question(nullptr,
-        tr("Are you sure?"),
-        tr("Do you really want to remove the share ") + drive.path + "?",
-        QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
-
-    if (answer != QMessageBox::Yes) {
-        return;
-    }
-
-    pCurrentExecution->removeDrive(drive);
-
-    pTailStatus->drives.removeAt(row);
-    ui->twSharedDrives->removeRow(row);
-    if (row > 0)
-        ui->twSharedDrives->selectRow(row - 1);
-
-    tailDrivesToUi();
-}
-
-void MainWindow::selectTailDriveMountPath() const {
-    QFileDialog dlg(nullptr, tr("Select mount path"), ui->txtTailDriveDefaultMountPath->text());
-    dlg.setOption(QFileDialog::Option::ShowDirsOnly, true);
-    dlg.setFileMode(QFileDialog::FileMode::Directory);
-
-    auto result = dlg.exec();
-    if (result == QDialog::Accepted) {
-        auto files = dlg.selectedFiles();
-        if (files.count() > 0) {
-            ui->txtTailDriveDefaultMountPath->setText(files.first());
-        }
-    }
-}
-
-void MainWindow::fixTailDriveDavFsSetup() const {
-    auto homeDir = KnownValues::getHomeDir();
-    auto homeDavFsSecret = KnownValues::getTailDriveFilePath();
-
-    if (isTailDriveFileAlreadySetup())
-        return;
-
-    // Create the .davfs2 folder if it doesn't exist
-    auto davDir = QDir(homeDir);
-    (void)davDir.mkpath(".davfs2"); // Don't care for return val
-
-    QFile davFsSecret(homeDavFsSecret);
-    davFsSecret.open(QIODevice::ReadWrite);
-
-    // We need to add our config lines
-    davFsSecret.seek(davFsSecret.size());
-    davFsSecret.write(QString("\n# Tailscale davfs server config\n").toUtf8());
-    davFsSecret.write(QString(KnownValues::tailDavFsUrl + "\tGuest\tGuest\n").toUtf8());
-
-    davFsSecret.close();
-
-    QMessageBox::information(nullptr, "Tail Tray", tr("davfs2 config has been written"));
-
-    ui->btnTailDriveFixDavFsMountSetup->setEnabled(isTailDriveFileAlreadySetup());
+    // And the UI for it
+    pTailDriveUiManager->stateChangedTo(eCurrentState, pTailStatus.get());
 }
 #endif
 
@@ -562,29 +456,6 @@ bool MainWindow::isTailDriveFileAlreadySetup() {
     return false;
 }
 
-#if defined(DAVFS_ENABLED)
-void MainWindow::tailDrivesToUi() const {
-    if (pTailStatus == nullptr) {
-        return;
-    }
-
-    const auto& drives = pTailStatus->drives;
-
-    ui->twSharedDrives->clearContents();
-    ui->twSharedDrives->setColumnCount(2);
-    ui->twSharedDrives->setHorizontalHeaderLabels(QStringList() << tr("Name") << tr("Path"));
-    ui->twSharedDrives->setRowCount(static_cast<int>(drives.count()));
-
-    for (int i = 0; i < drives.count(); i++) {
-        const auto& drive = drives[i];
-        qDebug() << "Drive: " << drive.name << " (" << drive.path << ")";
-
-        ui->twSharedDrives->setItem(i, 0, new QTableWidgetItem(drive.name));
-        ui->twSharedDrives->setItem(i, 1, new QTableWidgetItem(drive.path));
-    }
-}
-#endif
-
 void MainWindow::showEvent(QShowEvent *event) {
     QMainWindow::showEvent(event);
 
@@ -623,9 +494,10 @@ TailState MainWindow::changeToState(TailState newState)
         startListeningForIncomingFiles();
 
 #if defined(DAVFS_ENABLED)
-        if (settings.tailDriveEnabled()) {
-            pCurrentExecution->listDrives();
-        }
+    pTailDriveUiManager->stateChangedTo(newState, pTailStatus.get());
+    if (settings.tailDriveEnabled()) {
+        pCurrentExecution->listDrives();
+    }
 #endif
     }
 
@@ -729,9 +601,7 @@ void MainWindow::onTailStatusChanged(TailStatus* pNewStatus)
         }
     }
 
-#if defined(DAVFS_ENABLED)
-    tailDrivesToUi();
-#endif
+    pTailDriveUiManager->stateChangedTo(eCurrentState, pTailStatus.get());
 }
 
 bool MainWindow::shallowCheckForNetworkAvailable() {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -16,6 +16,10 @@
 #include "NetworkStateMonitor.h"
 #include "models/TailStatus.h"
 
+#if defined(DAVFS_ENABLED)
+#include "TailDriveUiManager.h"
+#endif
+
 class AccountsTabUiManager;
 
 class MainWindow : public QMainWindow
@@ -45,6 +49,9 @@ private:
     std::unique_ptr<TailDnsStatus> pDnsStatus;
     std::unique_ptr<TailFileReceiver> pFileReceiver;
     std::unique_ptr<NetworkStateMonitor> pNetworkStateMonitor;
+#if defined(DAVFS_ENABLED)
+    std::unique_ptr<TailDriveUiManager> pTailDriveUiManager;
+#endif
 
     TailState eCurrentState;
     TailSettings settings;
@@ -63,12 +70,6 @@ private slots:
 
 #if defined(DAVFS_ENABLED)
     void drivesListed(const QList<TailDriveInfo>& drives, bool error, const QString& errorMsg) const;
-
-    // Tail drive
-    void addTailDriveButtonClicked() const;
-    void removeTailDriveButtonClicked() const;
-    void selectTailDriveMountPath() const;
-    void fixTailDriveDavFsSetup() const;
 #endif
 
     // Send file
@@ -93,10 +94,6 @@ private:
     void setupNetworkCallbacks() const;
 
     [[nodiscard]] static bool isTailDriveFileAlreadySetup();
-
-#if defined(DAVFS_ENABLED)
-    void tailDrivesToUi() const;
-#endif
 
 protected:
     void showEvent(QShowEvent *event) override;

--- a/src/TailDriveUiManager.cpp
+++ b/src/TailDriveUiManager.cpp
@@ -1,0 +1,186 @@
+#include "TailDriveUiManager.h"
+#include <QMessageBox>
+#include <QFile>
+#include <QFileDialog>
+
+#include "KnownValues.h"
+#include "ManageDriveWindow.h"
+#include "MainWindow.h"
+
+#if defined(DAVFS_ENABLED)
+
+TailDriveUiManager::TailDriveUiManager(Ui::MainWindow* mainWndUi, TailRunner* runner, QObject* parent)
+    : QObject(parent)
+    , ui(mainWndUi)
+    , pTailRunner(runner)
+    , pTailStatus(nullptr)
+    , settings(this)
+{
+    connect(ui->btnAddTailDrive, &QPushButton::clicked,
+        this, &TailDriveUiManager::addTailDriveButtonClicked);
+
+    connect(ui->btnRemoveSelectedTailDrive, &QPushButton::clicked,
+            this, &TailDriveUiManager::removeTailDriveButtonClicked);
+
+    connect(ui->chkUseTailDrive, &QCheckBox::clicked,
+            this, [this]() {
+                auto checked = ui->chkUseTailDrive->isChecked();
+                settings.tailDriveEnabled(checked);
+
+                if (checked) {
+                    ui->tabWidget->insertTab(3, ui->tabTailDrive, QIcon::fromTheme("drive-removable-media"), "Tail Drive");
+                }
+                else {
+                    ui->tabWidget->removeTab(3);
+                }
+            });
+
+    connect(ui->btnSelectTailDriveMountPath, &QPushButton::clicked,
+            this, &TailDriveUiManager::selectTailDriveMountPath);
+
+    if (!isTailDriveFileAlreadySetup()) {
+        ui->btnTailDriveFixDavFsMountSetup->setEnabled(true);
+        ui->btnTailDriveFixDavFsMountSetup->setText(tr("Fix it for me"));
+        connect(ui->btnTailDriveFixDavFsMountSetup, &QPushButton::clicked,
+                this, &TailDriveUiManager::fixTailDriveDavFsSetup);
+    }
+    else {
+        ui->btnTailDriveFixDavFsMountSetup->setEnabled(false);
+        ui->btnTailDriveFixDavFsMountSetup->setText(tr("Configured and ready"));
+    }
+}
+
+void TailDriveUiManager::stateChangedTo(TailState newState, TailStatus* tailStatus) {
+    pTailStatus = tailStatus;
+    tailDrivesToUi();
+}
+
+void TailDriveUiManager::addTailDriveButtonClicked() const {
+    ManageDriveWindow dlg(TailDriveInfo{}, nullptr);
+    auto result = dlg.exec();
+    if (result == QDialog::Accepted) {
+        auto newDrive = dlg.driveInfo();
+        pTailRunner->addDrive(newDrive);
+
+        pTailStatus->drives.emplace_back(newDrive);
+        tailDrivesToUi();
+    }
+}
+
+void TailDriveUiManager::removeTailDriveButtonClicked() const {
+    auto selectedItems = ui->twSharedDrives->selectedItems();
+    if (selectedItems.count() < 1) {
+        return;
+    }
+
+    auto row = ui->twSharedDrives->row(selectedItems.first());
+    const auto& drive = pTailStatus->drives[row];
+
+    auto answer = QMessageBox::question(nullptr,
+        tr("Are you sure?"),
+        tr("Do you really want to remove the share ") + drive.path + "?",
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+
+    if (answer != QMessageBox::Yes) {
+        return;
+    }
+
+    pTailRunner->removeDrive(drive);
+
+    pTailStatus->drives.removeAt(row);
+    ui->twSharedDrives->removeRow(row);
+    if (row > 0)
+        ui->twSharedDrives->selectRow(row - 1);
+
+    tailDrivesToUi();
+}
+
+void TailDriveUiManager::selectTailDriveMountPath() const {
+    QFileDialog dlg(nullptr, tr("Select mount path"), ui->txtTailDriveDefaultMountPath->text());
+    dlg.setOption(QFileDialog::Option::ShowDirsOnly, true);
+    dlg.setFileMode(QFileDialog::FileMode::Directory);
+
+    auto result = dlg.exec();
+    if (result == QDialog::Accepted) {
+        auto files = dlg.selectedFiles();
+        if (files.count() > 0) {
+            ui->txtTailDriveDefaultMountPath->setText(files.first());
+        }
+    }
+}
+
+void TailDriveUiManager::fixTailDriveDavFsSetup() const {
+    auto homeDir = KnownValues::getHomeDir();
+    auto homeDavFsSecret = KnownValues::getTailDriveFilePath();
+
+    if (isTailDriveFileAlreadySetup())
+        return;
+
+    // Create the .davfs2 folder if it doesn't exist
+    auto davDir = QDir(homeDir);
+    (void)davDir.mkpath(".davfs2"); // Don't care for return val
+
+    QFile davFsSecret(homeDavFsSecret);
+    davFsSecret.open(QIODevice::ReadWrite);
+
+    // We need to add our config lines
+    davFsSecret.seek(davFsSecret.size());
+    davFsSecret.write(QString("\n# Tailscale davfs server config\n").toUtf8());
+    davFsSecret.write(QString(KnownValues::tailDavFsUrl + "\tGuest\tGuest\n").toUtf8());
+
+    davFsSecret.close();
+
+    QMessageBox::information(nullptr, "Tail Tray", tr("davfs2 config has been written"));
+
+    ui->btnTailDriveFixDavFsMountSetup->setEnabled(isTailDriveFileAlreadySetup());
+}
+
+void TailDriveUiManager::tailDrivesToUi() const {
+    if (pTailStatus == nullptr) {
+        return;
+    }
+
+    const auto& drives = pTailStatus->drives;
+
+    ui->twSharedDrives->clearContents();
+    ui->twSharedDrives->setColumnCount(2);
+    ui->twSharedDrives->setHorizontalHeaderLabels(QStringList() << tr("Name") << tr("Path"));
+    ui->twSharedDrives->setRowCount(static_cast<int>(drives.count()));
+
+    for (int i = 0; i < drives.count(); i++) {
+        const auto& drive = drives[i];
+        qDebug() << "Drive: " << drive.name << " (" << drive.path << ")";
+
+        ui->twSharedDrives->setItem(i, 0, new QTableWidgetItem(drive.name));
+        ui->twSharedDrives->setItem(i, 1, new QTableWidgetItem(drive.path));
+    }
+}
+
+bool TailDriveUiManager::isTailDriveFileAlreadySetup() {
+#if defined(WINDOWS_BUILD)
+    return true;
+#endif
+
+    auto homeDavFsSecret = KnownValues::getTailDriveFilePath();
+
+    // Create the .davfs2 folder if it doesn't exist
+    QFile davFsSecret(homeDavFsSecret);
+    if (!davFsSecret.open(QIODevice::ReadWrite)) {
+        davFsSecret.close();
+        return false;
+    }
+
+    auto fileContent = QString(davFsSecret.readAll());
+    auto lines = fileContent.split('\n', Qt::SkipEmptyParts);
+    for (const auto& line : lines) {
+        if (line.trimmed().startsWith('#'))
+            continue; // Comment
+        if (line.contains(KnownValues::tailDavFsUrl, Qt::CaseInsensitive)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+#endif /* DAVFS_ENABLED */

--- a/src/TailDriveUiManager.h
+++ b/src/TailDriveUiManager.h
@@ -1,0 +1,43 @@
+#ifndef TAILDRIVE_UI_MANAGER
+#define TAILDRIVE_UI_MANAGER
+
+// Only if told so by compiler flags
+#if defined(DAVFS_ENABLED)
+
+#include "TailRunner.h"
+#include "TailSettings.h"
+
+QT_BEGIN_NAMESPACE
+namespace Ui {
+class MainWindow;
+}
+QT_END_NAMESPACE
+
+class TailDriveUiManager : public QObject
+{
+Q_OBJECT
+public:
+    explicit TailDriveUiManager(Ui::MainWindow* mainWndUi, TailRunner* runner, QObject* parent = nullptr);
+
+    void stateChangedTo(TailState newState, TailStatus* tailStatus);
+
+private slots:
+    void addTailDriveButtonClicked() const;
+    void removeTailDriveButtonClicked() const;
+    void selectTailDriveMountPath() const;
+    void fixTailDriveDavFsSetup() const;
+
+private:
+    void tailDrivesToUi() const;
+    [[nodiscard]] static bool isTailDriveFileAlreadySetup();
+
+private:
+    Ui::MainWindow* ui;
+    TailRunner* pTailRunner;
+    TailStatus* pTailStatus;
+    TailSettings settings;
+};
+
+#endif /* DAVFS_ENABLED */
+
+#endif /* TAILDRIVE_UI_MANAGER */

--- a/src/TrayMenuManager.cpp
+++ b/src/TrayMenuManager.cpp
@@ -257,6 +257,12 @@ void TrayMenuManager::buildConnectedMenu(TailStatus const* pTailStatus) const {
                 connect(removeAction, &QAction::triggered, this, [this, drive](bool) {
                     pTailRunner->removeDrive(drive);
                 });
+
+                driveMenu->addSeparator();
+                auto* openAction = driveMenu->addAction(tr("Open in file manager"));
+                connect(openAction, &QAction::triggered, this, [this, drive](bool) {
+                    QDesktopServices::openUrl(QUrl(drive.path));
+                });
             }
 #endif
         }

--- a/src/models/TailDriveInfo.h
+++ b/src/models/TailDriveInfo.h
@@ -37,8 +37,8 @@ public:
     }
 
     static QList<TailDriveInfo> parse(const QString& rawString) {
-        QList<TailDriveInfo> parsedList;
-        static QRegularExpression re(R"((\w+)\s+([\w\/]+)\s+(\w+))");
+        QList<TailDriveInfo> parsedList{};
+        static QRegularExpression re(R"(^(\S+)\s+([\S\\/:\.]+)\s*(\S*)\s*$)");
 
         QStringList lines = rawString.split('\n');
         if (lines.count() < 3) {


### PR DESCRIPTION
This moves out the code for handling tail drives UI into it's own UI manager of sorts.
It also fixes a bug parsing tail drives from the tailscale drive list command output