### PR TITLE
When waiting for login, show cancel dialog #62

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -6,6 +6,7 @@
 #include <QNetworkInformation>
 #include <QMap>
 #include <QDateTime>
+#include <QDialog>
 
 #include "./ui_MainWindow.h"
 #include "TailRunner.h"
@@ -46,6 +47,7 @@ private:
     std::unique_ptr<AccountsTabUiManager> accountsTabUi;
     std::unique_ptr<TrayMenuManager> pTrayManager;
     std::unique_ptr<TailRunner> pCurrentExecution;
+    std::unique_ptr<QDialog> pLoginInProgressDlg;
     TailStatus pTailStatus{};
     TailDnsStatus pDnsStatus{};
     std::unique_ptr<TailFileReceiver> pFileReceiver;
@@ -67,7 +69,8 @@ private slots:
     void onAccountsListed(const QList<TailAccountInfo>& foundAccounts);
     void onCommandError(const QString& error, bool isSudoRequired);
     void settingsClosed();
-    void loginFlowCompleted() const;
+    void loginFlowStarting();
+    void loginFlowCompleted(bool success = true);
     void onIpnEvent(const IpnEventData& eventData);
 
 #if defined(DAVFS_ENABLED)

--- a/src/TailRunner.h
+++ b/src/TailRunner.h
@@ -46,6 +46,15 @@ public:
     [[nodiscard]] Command command() const { return eCommand; }
     [[nodiscard]] void* userData() const { return pUserData; }
     [[nodiscard]] bool isRunning() const { return proc != nullptr && proc->state() != QProcess::NotRunning; }
+    void cancel(bool raiseEvents = true) {
+        if (proc != nullptr) {
+            proc->terminate();
+        }
+
+        if (raiseEvents) {
+            emit processFinished(this, 0, QProcess::NormalExit);
+        }
+    }
 
 signals:
     void processCanReadStdOut(BufferedProcessWrapper* process);
@@ -76,7 +85,6 @@ public:
     void shutdown();
 
     void bootstrap();
-
     void readSettings();
     void readDnsStatus();
     void setOperator();
@@ -89,6 +97,7 @@ public:
 
     void login();
     void logout();
+    void cancelLoginFlow();
 
     void start(bool usePkExec = false);
     void stop();
@@ -114,7 +123,8 @@ signals:
     void dnsStatusRead(const TailDnsStatus& dnsStatus);
     void accountsListed(const QList<TailAccountInfo>& accounts);
     void statusUpdated(const TailStatus& newStatus);
-    void loginFlowCompleted();
+    void loginFlowStarting();
+    void loginFlowCompleted(bool success);
     void driveListed(const QList<TailDriveInfo>& drives, bool error, const QString& errorMsg);
     void fileSent(bool success, const QString& errorMsg, void* userData);
 

--- a/src/models/CurrentTailPrefs.h
+++ b/src/models/CurrentTailPrefs.h
@@ -212,7 +212,7 @@ public:
         , runSSH()
         , runWebClient()
         , wantRunning()
-        , loggedOut()
+        , loggedOut(true)
         , shieldsUp()
         , advertiseTags()
         , hostname()


### PR DESCRIPTION
 * We now show a basic cancel dialog with info in it when the login flow is running
 * The user can cancel the operation from that dialog
 * Dialog gets automatically dismissed on login flow completion (both success and failure state)
 * Fixed a few better UI states for when not logged in / disconnected vs connected in main window UI
 * Fixed a minor bug in the initial state where it would look like we're not connected when in reality we're not logged in