### PR TITLE
Warn if Tailscale isn't installed #66

### DIFF
--- a/src/IpnWatcher.cpp
+++ b/src/IpnWatcher.cpp
@@ -41,6 +41,10 @@ void IpnWatcher::start() {
 
 void IpnWatcher::stop() {
     m_isShuttingDown = true;
+    if (m_process == nullptr) {
+        return;
+    }
+
     if (m_process->state() == QProcess::Running) {
         m_process->terminate();
     }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -64,6 +64,7 @@ private:
     QMap<QString, QDateTime> seenWarningsAndErrors;
 
 private slots:
+    void tailscaleIsInstalled(bool installed);
     void settingsReadyToRead();
     void dnsStatusUpdated(const TailDnsStatus& dnsStatus);
     void onAccountsListed(const QList<TailAccountInfo>& foundAccounts);

--- a/src/TailRunner.h
+++ b/src/TailRunner.h
@@ -9,6 +9,7 @@
 #include "TailSettings.h"
 
 enum class Command {
+    CheckIfInstalled,
     SetOperator,
     SetExitNode,
     GetSettings,
@@ -57,11 +58,13 @@ public:
     }
 
 signals:
+    void processErrorOccurred(const BufferedProcessWrapper* wrapper, QProcess::ProcessError error);
     void processCanReadStdOut(BufferedProcessWrapper* process);
     void processCanReadStandardError(BufferedProcessWrapper* process);
     void processFinished(BufferedProcessWrapper* process, int exitCode, QProcess::ExitStatus exitStatus);
 
 private slots:
+    void onProcessErrorOccurred(QProcess::ProcessError error);
     void onProcessCanReadStdOut();
     void onProcessCanReadStandardError();
     void onProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
@@ -84,6 +87,7 @@ public:
 
     void shutdown();
 
+    void checkIfInstalled();
     void bootstrap();
     void readSettings();
     void readDnsStatus();
@@ -119,6 +123,7 @@ private:
     std::vector<BufferedProcessWrapper*> processes;
 
 signals:
+    void tailscaleIsInstalled(bool installed);
     void settingsRead();
     void dnsStatusRead(const TailDnsStatus& dnsStatus);
     void accountsListed(const QList<TailAccountInfo>& accounts);
@@ -139,6 +144,7 @@ private:
     void runCompletedCleanup();
 
 private slots:
+    void onProcessErrorOccurred(const BufferedProcessWrapper* wrapper, QProcess::ProcessError error);
     void onProcessCanReadStdOut(const BufferedProcessWrapper* wrapper);
     void onProcessCanReadStandardError(const BufferedProcessWrapper* wrapper);
     void onProcessFinished(const BufferedProcessWrapper* wrapper, int exitCode, QProcess::ExitStatus exitStatus);


### PR DESCRIPTION
 * This adds a pre-bootstrap check to see if the tailscale binary is installed/callable
 * If not, it will warn and close down
 * If it's present and callable, we'll bootstrap and run
 * Fixed a few shutdown issues/nullref checks needed