### PR TITLE
[Issue #36] - Initial try to use KNotification framework for notifications 

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -31,7 +31,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y \
           plasma-workspace-dev \
-          kf6-plasma-dev \
           extra-cmake-modules
 
     - name: Install Qt - Windows

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -24,14 +24,6 @@ jobs:
         version: '6.4.2'
         target: 'desktop'
         set-env: 'true'
-    
-    - name: Install KDE Deps - Linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          plasma-workspace-dev \
-          extra-cmake-modules
 
     - name: Install Qt - Windows
       if: runner.os == 'Windows'
@@ -55,6 +47,7 @@ jobs:
         echo "Running Linux build"
           cmake -B ${{ steps.strings.outputs.build-output-dir }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DKNOTIFICATIONS_ENABLED=OFF
             -S ${{ github.workspace }} \
             -G "Unix Makefiles" # Use Unix Makefiles for Ubuntu
       shell: bash  # This makes sure we use Bash on both platforms.

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -47,7 +47,7 @@ jobs:
         echo "Running Linux build"
           cmake -B ${{ steps.strings.outputs.build-output-dir }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DKNOTIFICATIONS_ENABLED=OFF
+            -DKNOTIFICATIONS_ENABLED=OFF \
             -S ${{ github.workspace }} \
             -G "Unix Makefiles" # Use Unix Makefiles for Ubuntu
       shell: bash  # This makes sure we use Bash on both platforms.
@@ -57,7 +57,7 @@ jobs:
       run: |
         echo "Running Windows build"
         echo "Build output directory: ${{ steps.strings.outputs.build-output-dir }}" 
-        cmake -B ${{ steps.strings.outputs.build-output-dir }} -DKNOTIFICATIONS_ENABLED=OFF -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -S ${{ github.workspace }} -G "Visual Studio 17 2022"
+        cmake -B ${{ steps.strings.outputs.build-output-dir }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -S ${{ github.workspace }} -G "Visual Studio 17 2022"
       shell: pwsh
 
     - name: Build

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         echo "Running Windows build"
         echo "Build output directory: ${{ steps.strings.outputs.build-output-dir }}" 
-        cmake -B ${{ steps.strings.outputs.build-output-dir }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -S ${{ github.workspace }} -G "Visual Studio 17 2022"
+        cmake -B ${{ steps.strings.outputs.build-output-dir }} -DKNOTIFICATIONS_ENABLED=OFF -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -S ${{ github.workspace }} -G "Visual Studio 17 2022"
       shell: pwsh
 
     - name: Build

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         echo "Running Windows build"
         echo "Build output directory: ${{ steps.strings.outputs.build-output-dir }}" 
-        cmake -B ${{ steps.strings.outputs.build-output-dir }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -S ${{ github.workspace }} -G "Visual Studio 17 2022"
+        cmake -B ${{ steps.strings.outputs.build-output-dir }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DKNOTIFICATIONS_ENABLED=OFF -S ${{ github.workspace }} -G "Visual Studio 17 2022"
       shell: pwsh
 
     - name: Build

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -24,6 +24,15 @@ jobs:
         version: '6.4.2'
         target: 'desktop'
         set-env: 'true'
+    
+    - name: Install KDE Deps - Linux
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          plasma-workspace-devel \
+          kf6-plasma-devel \
+          extra-cmake-modules
 
     - name: Install Qt - Windows
       if: runner.os == 'Windows'

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -30,8 +30,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
-          plasma-workspace-devel \
-          kf6-plasma-devel \
+          plasma-workspace-dev \
+          kf6-plasma-dev \
           extra-cmake-modules
 
     - name: Install Qt - Windows

--- a/.github/workflows/tagged-releases.yml
+++ b/.github/workflows/tagged-releases.yml
@@ -56,6 +56,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DKNOTIFICATIONS_ENABLED=OFF
         -S ${{ github.workspace }}
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,62 +35,68 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network LinguistT
 option(KNOTIFICATIONS_ENABLED "Enable KNotifications" ON)
 if (KNOTIFICATIONS_ENABLED)
     message("KNotifications has been enabled!")
+    find_package(ECM REQUIRED NO_MODULE)
+    set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+    include(KDEInstallDirs)
+    include(KDECMakeSettings)
+    include(KDECompilerSettings NO_POLICY_SCOPE)
+
     add_definitions(-DKNOTIFICATIONS_ENABLED)
     find_package(KF6Notifications)
 endif (KNOTIFICATIONS_ENABLED)
 
 set(PROJECT_SOURCES
-        src/main.cpp
-        src/MainWindow.cpp
-        src/MainWindow.h
-        src/MainWindow.ui
-        resources.qrc
-        src/models/TailAccountInfo.h
-        src/models/TailDeviceInfo.h
-        src/models/TailUser.h
-        src/models/TailNetInfo.h
-        src/models/TailDriveInfo.h
-        src/models/TailStatus.h
-        src/models/TailState.h
-        src/models/TailDnsStatus.h
-        src/models/CurrentTailPrefs.h
-        src/models/JsonHelpers.h
-        src/models/Models.h
-        src/models/IpnEvents.h 
-        src/TrayMenuManager.cpp
-        src/TrayMenuManager.h
-        src/TailSettings.cpp
-        src/TailSettings.h
-        src/AccountsTabUiManager.cpp
-        src/AccountsTabUiManager.h
-        src/SysCommand.cpp
-        src/SysCommand.h
-        src/KnownValues.h
-        src/TailFileReceiver.cpp
-        src/TailFileReceiver.h
-        src/TailRunner.h
-        src/TailRunner.cpp
-        src/TailDriveUiManager.h
-        src/TailDriveUiManager.cpp
-        src/ManageDriveWindow.h
-        src/ManageDriveWindow.cpp
-        src/ManageDriveWindow.ui
-        src/NetworkStateMonitor.cpp
-        src/NetworkStateMonitor.h
-        src/AdvertiseRoutesDlg.h
-        src/AdvertiseRoutesDlg.cpp
-        src/AdvertiseRoutesDlg.ui
-        src/DnsSettingsDlg.h
-        src/DnsSettingsDlg.cpp
-        src/DnsSettingsDlg.ui
-        src/IpnWatcher.cpp
-        src/IpnWatcher.h
-        src/SingleApplicationImpl.h
-        src/PleaseWaitDlg.h
-        src/PleaseWaitDlg.cpp
-        src/PleaseWaitDlg.ui
-        src/NotificationsManager.h
-        src/NotificationsManager.cpp
+    src/main.cpp
+    src/MainWindow.cpp
+    src/MainWindow.h
+    src/MainWindow.ui
+    resources.qrc
+    src/models/TailAccountInfo.h
+    src/models/TailDeviceInfo.h
+    src/models/TailUser.h
+    src/models/TailNetInfo.h
+    src/models/TailDriveInfo.h
+    src/models/TailStatus.h
+    src/models/TailState.h
+    src/models/TailDnsStatus.h
+    src/models/CurrentTailPrefs.h
+    src/models/JsonHelpers.h
+    src/models/Models.h
+    src/models/IpnEvents.h 
+    src/TrayMenuManager.cpp
+    src/TrayMenuManager.h
+    src/TailSettings.cpp
+    src/TailSettings.h
+    src/AccountsTabUiManager.cpp
+    src/AccountsTabUiManager.h
+    src/SysCommand.cpp
+    src/SysCommand.h
+    src/KnownValues.h
+    src/TailFileReceiver.cpp
+    src/TailFileReceiver.h
+    src/TailRunner.h
+    src/TailRunner.cpp
+    src/TailDriveUiManager.h
+    src/TailDriveUiManager.cpp
+    src/ManageDriveWindow.h
+    src/ManageDriveWindow.cpp
+    src/ManageDriveWindow.ui
+    src/NetworkStateMonitor.cpp
+    src/NetworkStateMonitor.h
+    src/AdvertiseRoutesDlg.h
+    src/AdvertiseRoutesDlg.cpp
+    src/AdvertiseRoutesDlg.ui
+    src/DnsSettingsDlg.h
+    src/DnsSettingsDlg.cpp
+    src/DnsSettingsDlg.ui
+    src/IpnWatcher.cpp
+    src/IpnWatcher.h
+    src/SingleApplicationImpl.h
+    src/PleaseWaitDlg.h
+    src/PleaseWaitDlg.cpp
+    src/PleaseWaitDlg.ui
+    src/NotificationsManager.h
+    src/NotificationsManager.cpp
 )
 
 if (APPLE)
@@ -145,16 +151,17 @@ target_link_libraries(
     KF6::Notifications
 )
 
+if (KNOTIFICATIONS_ENABLED)
+    target_link_libraries(
+        tail-tray PRIVATE 
+        KF6::Notifications
+    )
+endif (KNOTIFICATIONS_ENABLED)
+
 configure_file(src/Paths.h.in ${CMAKE_SOURCE_DIR}/src/Paths.h @ONLY)
 
 if (UNIX AND NOT APPLE)
-    find_package(ECM REQUIRED NO_MODULE)
-    set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
-
     include(GNUInstallDirs)
-    include(KDEInstallDirs)
-    include(KDECMakeSettings)
-    include(KDECompilerSettings NO_POLICY_SCOPE)
 endif ()
 
 install(TARGETS tail-tray

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network LinguistT
 option(KNOTIFICATIONS_ENABLED "Enable KNotifications" ON)
 if (KNOTIFICATIONS_ENABLED)
     message("KNotifications has been enabled! Make sure that you have KDE Frameworks installed and min. version 6+.")
-    
+
     find_package(ECM REQUIRED NO_MODULE)
     set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
     include(KDEInstallDirs)
@@ -152,7 +152,6 @@ target_link_libraries(
     tail-tray PRIVATE 
     Qt${QT_VERSION_MAJOR}::Widgets 
     Qt${QT_VERSION_MAJOR}::Network 
-    KF6::Notifications
 )
 
 if (KNOTIFICATIONS_ENABLED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,9 @@ find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets Network LinguistTools)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network LinguistTools)
 
 # Use KNotifications
-option(KNOTIFICATIONS_ENABLED "Enable KNotifications" OFF)
+option(KNOTIFICATIONS_ENABLED "Enable KNotifications" ON)
 if (KNOTIFICATIONS_ENABLED)
-    message("KNotifications has been enabled! Make sure that you have KDE Frameworks installed and min. version 6+.")
+    message("KNotifications has been enabled! This requires Plasma 6")
 
     find_package(ECM REQUIRED NO_MODULE)
     set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,14 @@ message(STATUS "Full path of translations install path: ${FULL_LIBDIR_PATH}")
 find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets Network LinguistTools)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network LinguistTools)
 
+# Use KNotifications
+option(KNOTIFICATIONS_ENABLED "Enable KNotifications" ON)
+if (KNOTIFICATIONS_ENABLED)
+    message("KNotifications has been enabled!")
+    add_definitions(-DKNOTIFICATIONS_ENABLED)
+    find_package(KF6Notifications)
+endif (KNOTIFICATIONS_ENABLED)
+
 set(PROJECT_SOURCES
         src/main.cpp
         src/MainWindow.cpp
@@ -81,6 +89,8 @@ set(PROJECT_SOURCES
         src/PleaseWaitDlg.h
         src/PleaseWaitDlg.cpp
         src/PleaseWaitDlg.ui
+        src/NotificationsManager.h
+        src/NotificationsManager.cpp
 )
 
 if (APPLE)
@@ -128,7 +138,12 @@ qt_add_translations(tail-tray TS_FILES
 )
 qt_standard_project_setup(I18N_TRANSLATED_LANGUAGES en_US sv_SE de_DE fr_FR)
 
-target_link_libraries(tail-tray PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Network)
+target_link_libraries(
+    tail-tray PRIVATE 
+    Qt${QT_VERSION_MAJOR}::Widgets 
+    Qt${QT_VERSION_MAJOR}::Network 
+    KF6::Notifications
+)
 
 configure_file(src/Paths.h.in ${CMAKE_SOURCE_DIR}/src/Paths.h @ONLY)
 
@@ -151,6 +166,10 @@ if (UNIX AND NOT APPLE)
     install(FILES tail-tray.desktop
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications
     )
+
+if (KNOTIFICATIONS_ENABLED)
+    install(FILES tail-tray.notifyrc DESTINATION "/usr/share/knotifications6")
+endif (KNOTIFICATIONS_ENABLED)
 
     install(FILES "${CMAKE_BINARY_DIR}/tail_tray_en_US.qm"
             "${CMAKE_BINARY_DIR}/tail_tray_sv_SE.qm"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ if (KNOTIFICATIONS_ENABLED)
     set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
     include(KDEInstallDirs)
     include(KDECMakeSettings)
-    include(KDECompilerSettings NO_POLICY_SCOPE)
 
     add_definitions(-DKNOTIFICATIONS_ENABLED)
     find_package(KF6Notifications)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets Network LinguistTools)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network LinguistTools)
 
 # Use KNotifications
-option(KNOTIFICATIONS_ENABLED "Enable KNotifications" ON)
+option(KNOTIFICATIONS_ENABLED "Enable KNotifications" OFF)
 if (KNOTIFICATIONS_ENABLED)
     message("KNotifications has been enabled! Make sure that you have KDE Frameworks installed and min. version 6+.")
 
@@ -45,7 +45,6 @@ if (KNOTIFICATIONS_ENABLED)
     find_package(KF6Notifications)
 else ()
     message("KNotifications has not been enabled!")
-    set(KNOTIFICATIONS_ENABLED OFF)
 endif (KNOTIFICATIONS_ENABLED)
 
 set(PROJECT_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,8 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Network LinguistT
 # Use KNotifications
 option(KNOTIFICATIONS_ENABLED "Enable KNotifications" ON)
 if (KNOTIFICATIONS_ENABLED)
-    message("KNotifications has been enabled!")
+    message("KNotifications has been enabled! Make sure that you have KDE Frameworks installed and min. version 6+.")
+    
     find_package(ECM REQUIRED NO_MODULE)
     set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
     include(KDEInstallDirs)
@@ -43,6 +44,9 @@ if (KNOTIFICATIONS_ENABLED)
 
     add_definitions(-DKNOTIFICATIONS_ENABLED)
     find_package(KF6Notifications)
+else ()
+    message("KNotifications has not been enabled!")
+    set(KNOTIFICATIONS_ENABLED OFF)
 endif (KNOTIFICATIONS_ENABLED)
 
 set(PROJECT_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,13 @@ target_link_libraries(
 configure_file(src/Paths.h.in ${CMAKE_SOURCE_DIR}/src/Paths.h @ONLY)
 
 if (UNIX AND NOT APPLE)
+    find_package(ECM REQUIRED NO_MODULE)
+    set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+
     include(GNUInstallDirs)
+    include(KDEInstallDirs)
+    include(KDECMakeSettings)
+    include(KDECompilerSettings NO_POLICY_SCOPE)
 endif ()
 
 install(TARGETS tail-tray
@@ -168,7 +174,7 @@ if (UNIX AND NOT APPLE)
     )
 
 if (KNOTIFICATIONS_ENABLED)
-    install(FILES tail-tray.notifyrc DESTINATION "/usr/share/knotifications6")
+    install(FILES "tail-tray.notifyrc" DESTINATION ${KDE_INSTALL_KNOTIFYRCDIR})
 endif (KNOTIFICATIONS_ENABLED)
 
     install(FILES "${CMAKE_BINARY_DIR}/tail_tray_en_US.qm"

--- a/docs/build-from-src.md
+++ b/docs/build-from-src.md
@@ -3,17 +3,17 @@
    * Git, QT 6, cmake and a c++ compiler, for example:
       * On Ubuntu and Ubuntu based distros
          ```bash
-         sudo apt install git qt6-tools-dev qt6-tools-dev-tools g++ clang cmake davfs2
+         sudo apt install git qt6-tools-dev qt6-tools-dev-tools g++ clang cmake davfs2 extra-cmake-modules
          ```
      * On Fedora
         ```bash
-        sudo dnf install -y git g++ clang cmake qt6-qtbase-devel qt6-qttools-devel qt6-qtbase-private-devel davfs2
+        sudo dnf install -y git g++ clang cmake qt6-qtbase-devel qt6-qttools-devel qt6-qtbase-private-devel davfs2 extra-cmake-modules
         ```
       * On Arch Linux
         * You can use the AUR package from here https://aur.archlinux.org/packages/tail-tray-git provided by @HeavenVolkoff
         * or, build it from source yourself:
          ```bash
-         sudo pacman -S git clang cmake qt6-base qt6-tools
+         sudo pacman -S git clang cmake qt6-base qt6-tools extra-cmake-modules
          ```
         ```bash 
         # For davfs2 we need to use the AUR

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -33,6 +33,9 @@ MainWindow::MainWindow(QWidget* parent)
 #if defined(DAVFS_ENABLED)
     , pTailDriveUiManager()
 #endif
+#if defined(KNOTIFICATIONS_ENABLED)
+    , pNotificationsManager()
+#endif
     , settings(this)
 {
     ui->setupUi(this);
@@ -403,9 +406,14 @@ void MainWindow::fileSentToDevice(bool success, const QString& errorMsg, void* u
     }
 
     auto userDataStr = static_cast<QString*>(userData);
+#if defined(KNOTIFICATIONS_ENABLED)
+    pNotificationsManager->showNotification(tr("File sent"), 
+        tr("The file %1 has been sent!").arg(*userDataStr), 
+        QVariant{}, "document-send");
+#else
     pTrayManager->trayIcon()->showMessage(tr("File sent"), *userDataStr, QSystemTrayIcon::MessageIcon::Information, 5000);
+#endif
 
-    // We need to delete this here
     delete userDataStr;
 }
 
@@ -426,10 +434,15 @@ void MainWindow::startListeningForIncomingFiles() {
 
 void MainWindow::onTailnetFileReceived(QString filePath) const {
     const QFileInfo file(filePath);
+#if defined(KNOTIFICATIONS_ENABLED)
+    pNotificationsManager->showFileNotification(tr("File received"), 
+        tr("File %1 has been saved in %2").arg(file.fileName()).arg(file.absolutePath()), 
+            file.absolutePath(), QVariant{}, "document-received");
+#else
     const QString msg("File " + file.fileName() + " was received and saved in " + file.absolutePath());
-
     pTrayManager->trayIcon()->showMessage(tr("File received"), msg,
         QSystemTrayIcon::MessageIcon::Information, 8000);
+#endif
 }
 
 void MainWindow::onShowTailFileSaveLocationPicker() {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -409,7 +409,7 @@ void MainWindow::fileSentToDevice(bool success, const QString& errorMsg, void* u
 #if defined(KNOTIFICATIONS_ENABLED)
     pNotificationsManager->showNotification(tr("File sent"), 
         tr("The file %1 has been sent!").arg(*userDataStr), 
-        QVariant{}, "document-send");
+        QVariant{});
 #else
     pTrayManager->trayIcon()->showMessage(tr("File sent"), *userDataStr, QSystemTrayIcon::MessageIcon::Information, 5000);
 #endif
@@ -437,7 +437,7 @@ void MainWindow::onTailnetFileReceived(QString filePath) const {
 #if defined(KNOTIFICATIONS_ENABLED)
     pNotificationsManager->showFileNotification(tr("File received"), 
         tr("File %1 has been saved in %2").arg(file.fileName()).arg(file.absolutePath()), 
-            file.absolutePath(), QVariant{}, "document-received");
+            file, QVariant{});
 #else
     const QString msg("File " + file.fileName() + " was received and saved in " + file.absolutePath());
     pTrayManager->trayIcon()->showMessage(tr("File received"), msg,

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -57,9 +57,7 @@ private:
 #if defined(DAVFS_ENABLED)
     std::unique_ptr<TailDriveUiManager> pTailDriveUiManager;
 #endif
-#if defined(KNOTIFICATIONS_ENABLED)
     std::unique_ptr<NotificationsManager> pNotificationsManager;
-#endif
 
     TailState eCurrentState;
     TailSettings settings;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -17,6 +17,7 @@
 #include "IpnWatcher.h"
 #include "models/TailStatus.h"
 #include "PleaseWaitDlg.h"
+#include "NotificationsManager.h"
 
 #if defined(DAVFS_ENABLED)
 #include "TailDriveUiManager.h"
@@ -55,6 +56,9 @@ private:
     std::unique_ptr<IpnWatcher> pIpnWatcher;
 #if defined(DAVFS_ENABLED)
     std::unique_ptr<TailDriveUiManager> pTailDriveUiManager;
+#endif
+#if defined(KNOTIFICATIONS_ENABLED)
+    std::unique_ptr<NotificationsManager> pNotificationsManager;
 #endif
 
     TailState eCurrentState;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -75,6 +75,7 @@ private slots:
     void loginFlowStarting(const QString& loginUrl);
     void loginFlowCompleted(bool success = true);
     void onIpnEvent(const IpnEventData& eventData);
+    void ipAddressCopiedToClipboard(const QString& ipAddress, const QString& hostname);
 
 #if defined(DAVFS_ENABLED)
     void drivesListed(const QList<TailDriveInfo>& drives, bool error, const QString& errorMsg);

--- a/src/NotificationsManager.cpp
+++ b/src/NotificationsManager.cpp
@@ -1,16 +1,16 @@
 #include "NotificationsManager.h"
 
-#if defined(KNOTIFICATIONS_ENABLED)
-
 #include <QDesktopServices>
 
-NotificationsManager::NotificationsManager(QObject* parent)
+NotificationsManager::NotificationsManager(TrayMenuManager const* pTrayMgr, QObject* parent)
     : QObject(parent)
+    , m_pTrayMgr(pTrayMgr)
 { }
 
 NotificationsManager::~NotificationsManager() = default;
 
-void NotificationsManager::showNotification(const QString& title, const QString& message, const QVariant& data, const QString& iconName) {
+void NotificationsManager::showNotification(const QString& title, const QString& message, const QString& iconName) {
+#if defined(KNOTIFICATIONS_ENABLED)
     auto* notification = new KNotification("BasicNotification", KNotification::NotificationFlag::Persistent, this);
     notification->setTitle(title);
     notification->setText(message);
@@ -21,11 +21,16 @@ void NotificationsManager::showNotification(const QString& title, const QString&
     }
 
     notification->sendEvent();
+#else
+    m_pTrayMgr->trayIcon()->showMessage(title, message,
+        QSystemTrayIcon::MessageIcon::Information, 5000);
+#endif
 }
 
 void NotificationsManager::showFileNotification(const QString& title, const QString& message, const QFileInfo& fileInfo,
-    const QVariant& data, const QString& iconName) {
+    const QString& iconName) {
 
+#if defined(KNOTIFICATIONS_ENABLED)
     auto* notification = new KNotification("FileTransfer", KNotification::NotificationFlag::Persistent, this);
     notification->setTitle(title);
     notification->setText(message);
@@ -40,6 +45,24 @@ void NotificationsManager::showFileNotification(const QString& title, const QStr
     }
 
     notification->sendEvent();
+#else
+    m_pTrayMgr->trayIcon()->showMessage(title, message,
+        QSystemTrayIcon::MessageIcon::Information, 5000);
+#endif
 }
 
+void NotificationsManager::showWarningNotification(const QString& title, const QString& message, const QString& iconName) {
+#if defined(KNOTIFICATIONS_ENABLED)
+    m_pTrayMgr->trayIcon()->showMessage(title, message, QSystemTrayIcon::Warning, 5000);
+#else
+    m_pTrayMgr->trayIcon()->showMessage(title, message, QSystemTrayIcon::Warning, 5000);
 #endif
+}
+
+void NotificationsManager::showErrorNotification(const QString& title, const QString& message, const QString& iconName) {
+#if defined(KNOTIFICATIONS_ENABLED)
+    m_pTrayMgr->trayIcon()->showMessage(title, message, QSystemTrayIcon::Critical, 5000);
+#else
+    m_pTrayMgr->trayIcon()->showMessage(title, message, QSystemTrayIcon::Critical, 5000);
+#endif
+}

--- a/src/NotificationsManager.cpp
+++ b/src/NotificationsManager.cpp
@@ -11,13 +11,16 @@ NotificationsManager::~NotificationsManager() = default;
 
 void NotificationsManager::showNotification(const QString& title, const QString& message, const QString& iconName) {
 #if defined(KNOTIFICATIONS_ENABLED)
-    auto* notification = new KNotification("BasicNotification", KNotification::NotificationFlag::Persistent, this);
+    auto* notification = new KNotification("BasicNotification", KNotification::NotificationFlag::CloseOnTimeout, this);
     notification->setTitle(title);
     notification->setText(message);
 
-    notification->setUrgency(KNotification::Urgency::HighUrgency);
+    notification->setUrgency(KNotification::Urgency::DefaultUrgency);
     if (!iconName.isEmpty()) {
         notification->setIconName(iconName);
+    }
+    else {
+        notification->setIconName("notification-active");
     }
 
     notification->sendEvent();
@@ -31,7 +34,7 @@ void NotificationsManager::showFileNotification(const QString& title, const QStr
     const QString& iconName) {
 
 #if defined(KNOTIFICATIONS_ENABLED)
-    auto* notification = new KNotification("FileTransfer", KNotification::NotificationFlag::Persistent, this);
+    auto* notification = new KNotification("FileTransfer", KNotification::NotificationFlag::CloseOnTimeout, this);
     notification->setTitle(title);
     notification->setText(message);
 
@@ -39,9 +42,12 @@ void NotificationsManager::showFileNotification(const QString& title, const QStr
     QUrl fileUrl("file://" + fileInfo.absoluteFilePath());
     notification->setUrls(QList{fileUrl});
 
-    notification->setUrgency(KNotification::Urgency::HighUrgency);
+    notification->setUrgency(KNotification::Urgency::DefaultUrgency);
     if (!iconName.isEmpty()) {
         notification->setIconName(iconName);
+    }
+    else {
+        notification->setIconName("edit-image");
     }
 
     notification->sendEvent();
@@ -53,7 +59,19 @@ void NotificationsManager::showFileNotification(const QString& title, const QStr
 
 void NotificationsManager::showWarningNotification(const QString& title, const QString& message, const QString& iconName) {
 #if defined(KNOTIFICATIONS_ENABLED)
-    m_pTrayMgr->trayIcon()->showMessage(title, message, QSystemTrayIcon::Warning, 5000);
+    auto* notification = new KNotification("BasicNotification", KNotification::NotificationFlag::CloseOnTimeout, this);
+    notification->setTitle(title);
+    notification->setText(message);
+
+    notification->setUrgency(KNotification::Urgency::DefaultUrgency);
+    if (!iconName.isEmpty()) {
+        notification->setIconName(iconName);
+    }
+    else {
+        notification->setIconName("dialog-warning");
+    }
+
+    notification->sendEvent();
 #else
     m_pTrayMgr->trayIcon()->showMessage(title, message, QSystemTrayIcon::Warning, 5000);
 #endif
@@ -61,7 +79,19 @@ void NotificationsManager::showWarningNotification(const QString& title, const Q
 
 void NotificationsManager::showErrorNotification(const QString& title, const QString& message, const QString& iconName) {
 #if defined(KNOTIFICATIONS_ENABLED)
-    m_pTrayMgr->trayIcon()->showMessage(title, message, QSystemTrayIcon::Critical, 5000);
+    auto* notification = new KNotification("BasicNotification", KNotification::NotificationFlag::CloseOnTimeout, this);
+    notification->setTitle(title);
+    notification->setText(message);
+
+    notification->setUrgency(KNotification::Urgency::DefaultUrgency);
+    if (!iconName.isEmpty()) {
+        notification->setIconName(iconName);
+    }
+    else {
+        notification->setIconName("dialog-error");
+    }
+
+    notification->sendEvent();
 #else
     m_pTrayMgr->trayIcon()->showMessage(title, message, QSystemTrayIcon::Critical, 5000);
 #endif

--- a/src/NotificationsManager.cpp
+++ b/src/NotificationsManager.cpp
@@ -1,0 +1,61 @@
+#include "NotificationsManager.h"
+
+#if defined(KNOTIFICATIONS_ENABLED)
+
+#include <QDesktopServices>
+
+NotificationsManager::NotificationsManager(QObject* parent)
+    : QObject(parent)
+{
+    
+}
+
+NotificationsManager::~NotificationsManager()
+{
+
+}
+
+void NotificationsManager::showNotification(const QString& title, const QString& message, const QVariant& data, const QString& iconName) {
+    KNotification* notification = new KNotification("BasicNotification", KNotification::NotificationFlag::CloseOnTimeout, this);
+    notification->setTitle(title);
+    notification->setText(message);
+
+    notification->setUrgency(KNotification::Urgency::HighUrgency);
+    if (!iconName.isEmpty()) {
+        notification->setIconName(iconName);
+    }
+
+    KNotificationAction* action = notification->addDefaultAction("View");
+    connect(action, &KNotificationAction::activated, this, [this, notification, action]() {
+        notification->close();
+
+        notification->deleteLater();
+        action->deleteLater();
+    });
+ 
+    notification->sendEvent();
+}
+
+void NotificationsManager::showFileNotification(const QString& title, const QString& message, const QString& filePath, const QVariant& data, const QString& iconName) {
+    KNotification* notification = new KNotification("FileTransfer", KNotification::NotificationFlag::CloseOnTimeout, this);
+    notification->setTitle(title);
+    notification->setText(message);
+
+    notification->setUrgency(KNotification::Urgency::HighUrgency);
+    if (!iconName.isEmpty()) {
+        notification->setIconName(iconName);
+    }
+
+    KNotificationAction* action = notification->addDefaultAction("Open Folder");
+    connect(action, &KNotificationAction::activated, this, [this, notification, action, filePath]() {
+        notification->close();
+        QDesktopServices::openUrl(QUrl("file://" + filePath));
+
+        notification->deleteLater();
+        action->deleteLater();
+    });
+
+    notification->sendEvent();
+}
+
+#endif

--- a/src/NotificationsManager.cpp
+++ b/src/NotificationsManager.cpp
@@ -6,17 +6,12 @@
 
 NotificationsManager::NotificationsManager(QObject* parent)
     : QObject(parent)
-{
-    
-}
+{ }
 
-NotificationsManager::~NotificationsManager()
-{
-
-}
+NotificationsManager::~NotificationsManager() = default;
 
 void NotificationsManager::showNotification(const QString& title, const QString& message, const QVariant& data, const QString& iconName) {
-    KNotification* notification = new KNotification("BasicNotification", KNotification::NotificationFlag::CloseOnTimeout, this);
+    auto* notification = new KNotification("BasicNotification", KNotification::NotificationFlag::Persistent, this);
     notification->setTitle(title);
     notification->setText(message);
 
@@ -25,35 +20,24 @@ void NotificationsManager::showNotification(const QString& title, const QString&
         notification->setIconName(iconName);
     }
 
-    KNotificationAction* action = notification->addDefaultAction("View");
-    connect(action, &KNotificationAction::activated, this, [this, notification, action]() {
-        notification->close();
-
-        notification->deleteLater();
-        action->deleteLater();
-    });
- 
     notification->sendEvent();
 }
 
-void NotificationsManager::showFileNotification(const QString& title, const QString& message, const QString& filePath, const QVariant& data, const QString& iconName) {
-    KNotification* notification = new KNotification("FileTransfer", KNotification::NotificationFlag::CloseOnTimeout, this);
+void NotificationsManager::showFileNotification(const QString& title, const QString& message, const QFileInfo& fileInfo,
+    const QVariant& data, const QString& iconName) {
+
+    auto* notification = new KNotification("FileTransfer", KNotification::NotificationFlag::Persistent, this);
     notification->setTitle(title);
     notification->setText(message);
+
+    // Setting the file URI will trigger the hamburger menu where one can select to open the file etc
+    QUrl fileUrl("file://" + fileInfo.absoluteFilePath());
+    notification->setUrls(QList{fileUrl});
 
     notification->setUrgency(KNotification::Urgency::HighUrgency);
     if (!iconName.isEmpty()) {
         notification->setIconName(iconName);
     }
-
-    KNotificationAction* action = notification->addDefaultAction("Open Folder");
-    connect(action, &KNotificationAction::activated, this, [this, notification, action, filePath]() {
-        notification->close();
-        QDesktopServices::openUrl(QUrl("file://" + filePath));
-
-        notification->deleteLater();
-        action->deleteLater();
-    });
 
     notification->sendEvent();
 }

--- a/src/NotificationsManager.h
+++ b/src/NotificationsManager.h
@@ -1,0 +1,24 @@
+#ifndef NOTIFICATIONS_MANAGER
+#define NOTIFICATIONS_MANAGER
+
+#include <QObject>
+#include <QList>
+#include <QVariant>
+#include <KNotification>
+
+#if defined(KNOTIFICATIONS_ENABLED)
+
+class NotificationsManager : public QObject
+{
+    Q_OBJECT
+public:
+    explicit NotificationsManager(QObject* parent = nullptr);
+    ~NotificationsManager() override;
+
+    void showNotification(const QString &title, const QString& message, const QVariant& data, const QString& iconName = QString());
+    void showFileNotification(const QString& title, const QString& message, const QString& filePath, const QVariant& data, const QString& iconName = QString());
+};
+
+#endif // KNOTIFICATIONS_ENABLED
+
+#endif // NOTIFICATIONS_MANAGER

--- a/src/NotificationsManager.h
+++ b/src/NotificationsManager.h
@@ -3,9 +3,8 @@
 
 #if defined(KNOTIFICATIONS_ENABLED)
 
-#include <QObject>
 #include <QList>
-#include <QVariant>
+#include <QFileInfo>
 #include <KNotification>
 
 class NotificationsManager : public QObject
@@ -16,7 +15,8 @@ public:
     ~NotificationsManager() override;
 
     void showNotification(const QString &title, const QString& message, const QVariant& data, const QString& iconName = QString());
-    void showFileNotification(const QString& title, const QString& message, const QString& filePath, const QVariant& data, const QString& iconName = QString());
+    void showFileNotification(const QString& title, const QString& message, const QFileInfo& fileInfo,
+        const QVariant& data, const QString& iconName = QString());
 };
 
 #endif // KNOTIFICATIONS_ENABLED

--- a/src/NotificationsManager.h
+++ b/src/NotificationsManager.h
@@ -1,12 +1,12 @@
 #ifndef NOTIFICATIONS_MANAGER
 #define NOTIFICATIONS_MANAGER
 
+#if defined(KNOTIFICATIONS_ENABLED)
+
 #include <QObject>
 #include <QList>
 #include <QVariant>
 #include <KNotification>
-
-#if defined(KNOTIFICATIONS_ENABLED)
 
 class NotificationsManager : public QObject
 {

--- a/src/NotificationsManager.h
+++ b/src/NotificationsManager.h
@@ -20,8 +20,8 @@ public:
     void showFileNotification(const QString& title, const QString& message, const QFileInfo& fileInfo,
         const QString& iconName = QString());
 
-    void showWarningNotification(const QString& title, const QString& message, const QString& iconName = QString());
-    void showErrorNotification(const QString& title, const QString& message, const QString& iconName = QString());
+    void showWarningNotification(const QString& title, const QString& message, const QString& iconName = QString("dialog-warning"));
+    void showErrorNotification(const QString& title, const QString& message, const QString& iconName = QString("dialog-error"));
 
 private:
     TrayMenuManager const* m_pTrayMgr;

--- a/src/NotificationsManager.h
+++ b/src/NotificationsManager.h
@@ -1,24 +1,30 @@
 #ifndef NOTIFICATIONS_MANAGER
 #define NOTIFICATIONS_MANAGER
 
-#if defined(KNOTIFICATIONS_ENABLED)
-
-#include <QList>
 #include <QFileInfo>
+
+#if defined(KNOTIFICATIONS_ENABLED)
 #include <KNotification>
+#endif
+
+#include "TrayMenuManager.h"
 
 class NotificationsManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit NotificationsManager(QObject* parent = nullptr);
+    explicit NotificationsManager(TrayMenuManager const* pTrayMgr, QObject* parent = nullptr);
     ~NotificationsManager() override;
 
-    void showNotification(const QString &title, const QString& message, const QVariant& data, const QString& iconName = QString());
+    void showNotification(const QString &title, const QString& message, const QString& iconName = QString());
     void showFileNotification(const QString& title, const QString& message, const QFileInfo& fileInfo,
-        const QVariant& data, const QString& iconName = QString());
-};
+        const QString& iconName = QString());
 
-#endif // KNOTIFICATIONS_ENABLED
+    void showWarningNotification(const QString& title, const QString& message, const QString& iconName = QString());
+    void showErrorNotification(const QString& title, const QString& message, const QString& iconName = QString());
+
+private:
+    TrayMenuManager const* m_pTrayMgr;
+};
 
 #endif // NOTIFICATIONS_MANAGER

--- a/src/TrayMenuManager.h
+++ b/src/TrayMenuManager.h
@@ -19,9 +19,12 @@ public:
     explicit TrayMenuManager(TailSettings& s, TailRunner* runner, QObject* parent = nullptr);
 
     void onAccountsListed(const QList<TailAccountInfo>& foundAccounts);
-    void stateChangedTo(TailState newState, const TailStatus& pTailStatus) const;
+    void stateChangedTo(TailState newState, const TailStatus& pTailStatus);
 
     [[nodiscard]] QSystemTrayIcon* trayIcon() const { return pSysTray.get(); }
+
+signals:
+    void ipAddressCopiedToClipboard(const QString& ipAddress, const QString& hostname);
 
 private:
     QList<TailAccountInfo> accounts;
@@ -46,7 +49,7 @@ private:
 private:
     void buildNotLoggedInMenu() const;
     void buildNotConnectedMenu(const TailStatus& pTailStatus) const;
-    void buildConnectedMenu(const TailStatus& pTailStatus) const;
+    void buildConnectedMenu(const TailStatus& pTailStatus);
     void buildAccountsMenu() const;
 
     void setupWellKnownActions() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 int main(int argc, char** argv) {
     QCoreApplication::setOrganizationName("grenangen");
     QCoreApplication::setOrganizationDomain("grenangen.se");
-    QCoreApplication::setApplicationName("Tail Tray");
+    QCoreApplication::setApplicationName("tail-tray");
 
     SingleApplicationImpl a(argc, argv);
     if (!a.claimInstance()) {

--- a/tail-tray.notifyrc
+++ b/tail-tray.notifyrc
@@ -1,0 +1,17 @@
+[Global]
+    IconName=tailscale
+    Name=Tail Tray
+    Comment=A Tailscale Tray Application
+    DesktopEntry=Tail Tray
+
+[Event/BasicNotification]
+    Name=BasicNotification
+    Comment=Basic notifications without actions
+    Action=Sound|Popup
+    Urgency=Normal
+
+[Event/FileTransfer]
+    Name=FileTransfer
+    Comment=A file have been sent or received on this machine over Tailscale/Wireguard
+    Action=Sound|Popup
+    Urgency=Normal


### PR DESCRIPTION
This PR will resolve #36 - Interactive notification toasts.

We add support for using KNotification on supported systems that has Plasma 6 or newer. All other will have it disabled/will have to disable it for the build to work.

This also means that Ubuntu LTS releases won't have this interactive notification until they officially ship LTS with Plasma 6 and newer, so 26.04 time frame. Same goes with Debian stable.

For all others, it should just work making sure that `KNOTIFICATIONS_ENABLED` is turned on (It's on by default when building from source)